### PR TITLE
IS-2240: Legger til lagring av behandler melding om vedtak

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/VedtakEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/VedtakEndpoints.kt
@@ -36,7 +36,8 @@ fun Route.registerVedtakEndpoints(
                 throw IllegalArgumentException("Vedtak can't have an empty begrunnelse or document")
             }
 
-            val personident = call.getPersonident() ?: throw IllegalArgumentException("Failed to $API_ACTION: No $NAV_PERSONIDENT_HEADER supplied in request header")
+            val personident = call.getPersonident()
+                ?: throw IllegalArgumentException("Failed to $API_ACTION: No $NAV_PERSONIDENT_HEADER supplied in request header")
             val navIdent = call.getNAVIdent()
             val callId = call.getCallId()
 
@@ -48,6 +49,9 @@ fun Route.registerVedtakEndpoints(
                 fom = requestDTO.fom,
                 tom = requestDTO.tom,
                 callId = callId,
+                behandlerRef = requestDTO.behandlerRef,
+                behandlerNavn = requestDTO.behandlerNavn,
+                behandlerDocument = requestDTO.behandlerDocument,
             )
 
             call.respond(HttpStatusCode.Created, VedtakResponseDTO.createFromVedtak(vedtak = newVedtak))

--- a/src/main/kotlin/no/nav/syfo/api/model/VedtakRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/VedtakRequestDTO.kt
@@ -10,5 +10,6 @@ data class VedtakRequestDTO(
     val fom: LocalDate,
     val tom: LocalDate,
     val behandlerRef: UUID,
+    val behandlerNavn: String,
     val behandlerDocument: List<DocumentComponent>,
 )

--- a/src/main/kotlin/no/nav/syfo/application/IPdfService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IPdfService.kt
@@ -1,10 +1,17 @@
 package no.nav.syfo.application
 
+import no.nav.syfo.domain.BehandlerMelding
 import no.nav.syfo.domain.Vedtak
 
 interface IPdfService {
     suspend fun createVedtakPdf(
         vedtak: Vedtak,
+        callId: String,
+    ): ByteArray
+
+    suspend fun createBehandlerMeldingPdf(
+        behandlerMelding: BehandlerMelding,
+        behandlerNavn: String,
         callId: String,
     ): ByteArray
 }

--- a/src/main/kotlin/no/nav/syfo/application/IVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVedtakRepository.kt
@@ -1,12 +1,15 @@
 package no.nav.syfo.application
 
+import no.nav.syfo.domain.BehandlerMelding
 import no.nav.syfo.domain.Vedtak
 
 interface IVedtakRepository {
     fun createVedtak(
         vedtak: Vedtak,
-        pdf: ByteArray,
-    ): Vedtak
+        vedtakPdf: ByteArray,
+        behandlerMelding: BehandlerMelding,
+        behandlerMeldingPdf: ByteArray,
+    ): Pair<Vedtak, BehandlerMelding>
 
     fun getNotJournalforteVedtak(): List<Pair<Vedtak, ByteArray>>
 

--- a/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
@@ -1,9 +1,11 @@
 package no.nav.syfo.application
 
+import no.nav.syfo.domain.BehandlerMelding
 import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Vedtak
 import java.time.LocalDate
+import java.util.*
 
 class VedtakService(
     private val pdfService: IPdfService,
@@ -18,6 +20,9 @@ class VedtakService(
         fom: LocalDate,
         tom: LocalDate,
         callId: String,
+        behandlerRef: UUID,
+        behandlerNavn: String,
+        behandlerDocument: List<DocumentComponent>,
     ): Vedtak {
         val vedtak = Vedtak(
             personident = personident,
@@ -27,13 +32,25 @@ class VedtakService(
             fom = fom,
             tom = tom,
         )
+        val behandlerMelding = BehandlerMelding(
+            behandlerRef = behandlerRef,
+            document = behandlerDocument,
+        )
         val vedtakPdf = pdfService.createVedtakPdf(vedtak = vedtak, callId = callId)
-        val createdVedtak = vedtakRepository.createVedtak(
+        val behandlerMeldingPdf =
+            pdfService.createBehandlerMeldingPdf(
+                behandlerMelding = behandlerMelding,
+                behandlerNavn = behandlerNavn,
+                callId = callId
+            )
+        val (createdVedtak, createdBehandlerMelding) = vedtakRepository.createVedtak(
             vedtak = vedtak,
-            pdf = vedtakPdf,
+            vedtakPdf = vedtakPdf,
+            behandlerMelding = behandlerMelding,
+            behandlerMeldingPdf = behandlerMeldingPdf,
         )
 
-        // TODO: Lage melding til behandler inkl pdf, lagre denne og produsere til isdialogmelding
+        // TODO: Publiserer behandlermelding på kafka til isdialogmelding
 
         return createdVedtak
     }

--- a/src/main/kotlin/no/nav/syfo/domain/BehandlerMelding.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/BehandlerMelding.kt
@@ -1,0 +1,44 @@
+package no.nav.syfo.domain
+
+import no.nav.syfo.util.nowUTC
+import java.time.OffsetDateTime
+import java.util.*
+
+data class BehandlerMelding private constructor(
+    val uuid: UUID,
+    val createdAt: OffsetDateTime,
+    val behandlerRef: UUID,
+    val document: List<DocumentComponent>,
+    val journalpostId: JournalpostId?,
+) {
+    constructor(
+        behandlerRef: UUID,
+        document: List<DocumentComponent>,
+    ) : this(
+        uuid = behandlerRef,
+        createdAt = nowUTC(),
+        behandlerRef = behandlerRef,
+        document = document,
+        journalpostId = null,
+    )
+
+    fun journalfor(journalpostId: JournalpostId): BehandlerMelding = this.copy(journalpostId = journalpostId)
+
+    companion object {
+
+        fun fromDatabase(
+            uuid: UUID,
+            createdAt: OffsetDateTime,
+            behandlerRef: UUID,
+            document: List<DocumentComponent>,
+            journalpostId: JournalpostId?,
+        ) =
+            BehandlerMelding(
+                uuid = uuid,
+                createdAt = createdAt,
+                behandlerRef = behandlerRef,
+                document = document,
+                journalpostId = journalpostId,
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PBehandlerMelding.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PBehandlerMelding.kt
@@ -1,0 +1,27 @@
+package no.nav.syfo.infrastructure.database.repository
+
+import no.nav.syfo.domain.BehandlerMelding
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.JournalpostId
+import java.time.OffsetDateTime
+import java.util.*
+
+data class PBehandlerMelding(
+    val id: Int,
+    val uuid: UUID,
+    val createdAt: OffsetDateTime,
+    val updatedAt: OffsetDateTime,
+    val behandlerRef: UUID,
+    val document: List<DocumentComponent>,
+    val journalpostId: JournalpostId?,
+    val vedtakId: Int,
+    val pdfId: Int,
+) {
+    fun toBehandlerMelding(): BehandlerMelding = BehandlerMelding.fromDatabase(
+        uuid = uuid,
+        createdAt = createdAt,
+        behandlerRef = behandlerRef,
+        document = document,
+        journalpostId = journalpostId,
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VedtakRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VedtakRepository.kt
@@ -2,9 +2,7 @@ package no.nav.syfo.infrastructure.database.repository
 
 import com.fasterxml.jackson.core.type.TypeReference
 import no.nav.syfo.application.IVedtakRepository
-import no.nav.syfo.domain.DocumentComponent
-import no.nav.syfo.domain.Personident
-import no.nav.syfo.domain.Vedtak
+import no.nav.syfo.domain.*
 import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.database.toList
 import no.nav.syfo.util.configuredJacksonMapper
@@ -21,16 +19,28 @@ private val mapper = configuredJacksonMapper()
 
 class VedtakRepository(private val database: DatabaseInterface) : IVedtakRepository {
 
-    override fun createVedtak(vedtak: Vedtak, pdf: ByteArray): Vedtak {
+    override fun createVedtak(
+        vedtak: Vedtak,
+        vedtakPdf: ByteArray,
+        behandlerMelding: BehandlerMelding,
+        behandlerMeldingPdf: ByteArray
+    ): Pair<Vedtak, BehandlerMelding> {
         database.connection.use { connection ->
-            val pPdf = connection.createPdf(pdf = pdf)
+            val pVedtakPdf = connection.createPdf(pdf = vedtakPdf)
             val pVedtak = connection.createVedtak(
                 vedtak = vedtak,
-                pdfId = pPdf.id
+                pdfId = pVedtakPdf.id
             )
-            connection.commit()
 
-            return pVedtak.toVedtak()
+            val pBehandlerMeldingPdf = connection.createPdf(pdf = behandlerMeldingPdf)
+            val pBehandlerMelding = connection.createBehandlerMelding(
+                behandlerMelding = behandlerMelding,
+                vedtakId = pVedtak.id,
+                pdfId = pBehandlerMeldingPdf.id
+            )
+
+            connection.commit()
+            return Pair(pVedtak.toVedtak(), pBehandlerMelding.toBehandlerMelding())
         }
     }
 
@@ -80,6 +90,18 @@ class VedtakRepository(private val database: DatabaseInterface) : IVedtakReposit
             it.executeQuery().toList { toPVedtak() }.single()
         }
 
+    private fun Connection.createBehandlerMelding(behandlerMelding: BehandlerMelding, vedtakId: Int, pdfId: Int) =
+        prepareStatement(CREATE_BEHANDLER_MELDING).use {
+            it.setString(1, behandlerMelding.uuid.toString())
+            it.setObject(2, behandlerMelding.createdAt)
+            it.setObject(3, behandlerMelding.createdAt)
+            it.setString(4, behandlerMelding.behandlerRef.toString())
+            it.setObject(5, mapper.writeValueAsString(behandlerMelding.document))
+            it.setInt(6, vedtakId)
+            it.setInt(7, pdfId)
+            it.executeQuery().toList { toPBehandlerMelding() }.single()
+        }
+
     companion object {
         private const val CREATE_PDF =
             """
@@ -122,6 +144,21 @@ class VedtakRepository(private val database: DatabaseInterface) : IVedtakReposit
                  INNER JOIN pdf p ON v.pdf_id = p.id
                  WHERE v.journalpost_id IS NULL
             """
+
+        private const val CREATE_BEHANDLER_MELDING =
+            """
+                INSERT INTO BEHANDLER_MELDING (
+                    id,
+                    uuid,
+                    created_at,
+                    updated_at,
+                    behandler_ref,
+                    document,
+                    vedtak_id,
+                    pdf_id
+                ) values (DEFAULT, ?, ?, ?, ?, ?::jsonb, ?, ?)
+                RETURNING *
+            """
     }
 }
 
@@ -147,5 +184,20 @@ internal fun ResultSet.toPVedtak(): PVedtak = PVedtak(
         object : TypeReference<List<DocumentComponent>>() {}
     ),
     journalpostId = getString("journalpost_id"),
+    pdfId = getInt("pdf_id"),
+)
+
+internal fun ResultSet.toPBehandlerMelding(): PBehandlerMelding = PBehandlerMelding(
+    id = getInt("id"),
+    uuid = UUID.fromString(getString("uuid")),
+    createdAt = getObject("created_at", OffsetDateTime::class.java),
+    updatedAt = getObject("updated_at", OffsetDateTime::class.java),
+    behandlerRef = UUID.fromString(getString("behandler_ref")),
+    document = mapper.readValue(
+        getString("document"),
+        object : TypeReference<List<DocumentComponent>>() {}
+    ),
+    journalpostId = getString("journalpost_id")?.let { JournalpostId(it) },
+    vedtakId = getInt("vedtak_id"),
     pdfId = getInt("pdf_id"),
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdf/PdfService.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.infrastructure.pdf
 
 import no.nav.syfo.application.IPdfService
+import no.nav.syfo.domain.BehandlerMelding
 import no.nav.syfo.domain.Vedtak
 import no.nav.syfo.infrastructure.clients.pdfgen.PdfGenClient
 import no.nav.syfo.infrastructure.clients.pdfgen.PdfModel.*
@@ -25,6 +26,21 @@ class PdfService(
         return pdfGenClient.createVedtakPdf(
             callId = callId,
             payload = vedtakPdfModel,
+        )
+    }
+
+    override suspend fun createBehandlerMeldingPdf(
+        behandlerMelding: BehandlerMelding,
+        behandlerNavn: String,
+        callId: String
+    ): ByteArray {
+        val behandlerMeldingPdfModel = BehandlerMeldingPdfModel(
+            mottakerNavn = behandlerNavn,
+            documentComponents = behandlerMelding.document,
+        )
+        return pdfGenClient.createBehandlerPdf(
+            callId = callId,
+            payload = behandlerMeldingPdfModel,
         )
     }
 }

--- a/src/test/kotlin/no/nav/syfo/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/UserConstants.kt
@@ -11,7 +11,7 @@ object UserConstants {
     val ARBEIDSTAKER_PERSONIDENT_PDL_FAILS = Personident("11111111666")
 
     val PDF_VEDTAK = byteArrayOf(0x2E, 0x28)
-    val PDF_BEHANDLER = byteArrayOf(0x2E, 0x30)
+    val PDF_BEHANDLER_MELDING = byteArrayOf(0x2E, 0x30)
     const val VEILEDER_IDENT = "Z999999"
 
     const val PERSON_FORNAVN = "Fornavn"
@@ -19,6 +19,4 @@ object UserConstants {
     const val PERSON_ETTERNAVN = "Etternavnesen"
     const val PERSON_FORNAVN_DASH = "For-Navn"
     const val PERSON_FULLNAME_DASH = "For-Navn Mellomnavn Etternavnesen"
-
-    val EXISTING_EKSTERN_REFERANSE_UUID: UUID = UUID.fromString("e7e8e9e0-e1e2-e3e4-e5e6-e7e8e9e0e1e2")
 }

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
@@ -54,6 +54,7 @@ object VedtakEndpointsSpek : Spek({
                 fom = vedtakFom,
                 tom = vedtakTom,
                 behandlerRef = UUID.randomUUID(),
+                behandlerNavn = "Beate Behandler",
                 behandlerDocument = generateDocumentComponent("Til orientering", header = "Informasjon om vedtak"),
             )
 

--- a/src/test/kotlin/no/nav/syfo/application/VedtakServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/VedtakServiceSpek.kt
@@ -22,6 +22,7 @@ import org.spekframework.spek2.style.specification.describe
 
 val vedtak = generateVedtak()
 val behandlerMelding = generateBehandlerMelding()
+val otherBehandlerMelding = generateBehandlerMelding()
 
 class VedtakServiceSpek : Spek({
     describe(VedtakService::class.java.simpleName) {
@@ -100,7 +101,9 @@ class VedtakServiceSpek : Spek({
                 val failingVedtak = generateVedtak().copy(uuid = UserConstants.FAILING_EKSTERN_REFERANSE_UUID)
                 vedtakRepository.createVedtak(
                     vedtak = failingVedtak,
-                    pdf = UserConstants.PDF_VEDTAK,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
                 )
 
                 val journalforteVedtak = runBlocking { vedtakService.journalforVedtak() }
@@ -115,7 +118,9 @@ class VedtakServiceSpek : Spek({
                 val failingVedtak = generateVedtak(personident = UserConstants.ARBEIDSTAKER_PERSONIDENT_PDL_FAILS)
                 vedtakRepository.createVedtak(
                     vedtak = failingVedtak,
-                    pdf = UserConstants.PDF_VEDTAK,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
                 )
 
                 val journalforteVedtak = runBlocking { vedtakService.journalforVedtak() }
@@ -130,12 +135,14 @@ class VedtakServiceSpek : Spek({
                 val failingVedtak = generateVedtak(personident = UserConstants.ARBEIDSTAKER_PERSONIDENT_PDL_FAILS)
                 vedtakRepository.createVedtak(
                     vedtak = failingVedtak,
-                    pdf = UserConstants.PDF_VEDTAK,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
                 )
                 vedtakRepository.createVedtak(
                     vedtak = vedtak,
                     vedtakPdf = UserConstants.PDF_VEDTAK,
-                    behandlerMelding = behandlerMelding,
+                    behandlerMelding = otherBehandlerMelding,
                     behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
                 )
 

--- a/src/test/kotlin/no/nav/syfo/application/VedtakServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/VedtakServiceSpek.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
 import no.nav.syfo.domain.JournalpostId
+import no.nav.syfo.generator.generateBehandlerMelding
 import no.nav.syfo.generator.generateVedtak
 import no.nav.syfo.infrastructure.database.dropData
 import no.nav.syfo.infrastructure.database.getVedtak
@@ -21,6 +22,7 @@ import org.spekframework.spek2.style.specification.describe
 
 val mockedJournalpostId = JournalpostId("123")
 val vedtak = generateVedtak()
+val behandlerMelding = generateBehandlerMelding()
 
 class VedtakServiceSpek : Spek({
     describe(VedtakService::class.java.simpleName) {
@@ -51,9 +53,16 @@ class VedtakServiceSpek : Spek({
             it("journalfører vedtak som ikke er journalført") {
                 vedtakRepository.createVedtak(
                     vedtak = vedtak,
-                    pdf = UserConstants.PDF_VEDTAK,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
                 )
-                coEvery { journalforingServiceMock.journalfor(any(), any()) } returns Result.success(mockedJournalpostId)
+                coEvery {
+                    journalforingServiceMock.journalfor(
+                        any(),
+                        any()
+                    )
+                } returns Result.success(mockedJournalpostId)
 
                 val journalforteVedtak = runBlocking { vedtakService.journalforVedtak() }
 
@@ -79,12 +88,19 @@ class VedtakServiceSpek : Spek({
             it("journalfører ikke når vedtak allerede er journalført") {
                 vedtakRepository.createVedtak(
                     vedtak = vedtak,
-                    pdf = UserConstants.PDF_VEDTAK,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
                 )
                 val journafortVedtak = vedtak.journalfor(mockedJournalpostId)
                 vedtakRepository.update(journafortVedtak)
 
-                coEvery { journalforingServiceMock.journalfor(any(), any()) } returns Result.success(mockedJournalpostId)
+                coEvery {
+                    journalforingServiceMock.journalfor(
+                        any(),
+                        any()
+                    )
+                } returns Result.success(mockedJournalpostId)
 
                 val journalforteVedtak = runBlocking { vedtakService.journalforVedtak() }
 
@@ -94,10 +110,17 @@ class VedtakServiceSpek : Spek({
             it("journalføring feiler") {
                 vedtakRepository.createVedtak(
                     vedtak = vedtak,
-                    pdf = UserConstants.PDF_VEDTAK,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
                 )
 
-                coEvery { journalforingServiceMock.journalfor(any(), any()) } returns Result.failure(Exception("Journalforing failed"))
+                coEvery {
+                    journalforingServiceMock.journalfor(
+                        any(),
+                        any()
+                    )
+                } returns Result.failure(Exception("Journalforing failed"))
 
                 val journalforteVedtak = runBlocking { vedtakService.journalforVedtak() }
 

--- a/src/test/kotlin/no/nav/syfo/generator/Generator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/Generator.kt
@@ -1,10 +1,12 @@
 package no.nav.syfo.generator
 
 import no.nav.syfo.UserConstants
+import no.nav.syfo.domain.BehandlerMelding
 import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Vedtak
 import java.time.LocalDate
+import java.util.*
 
 fun generateVedtak(
     personident: Personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
@@ -17,4 +19,11 @@ fun generateVedtak(
     document = document,
     fom = LocalDate.now(),
     tom = LocalDate.now().plusWeeks(12),
+)
+
+fun generateBehandlerMelding(
+    document: List<DocumentComponent> = generateDocumentComponent("En behandlermelding"),
+): BehandlerMelding = BehandlerMelding(
+    behandlerRef = UUID.randomUUID(),
+    document = document,
 )

--- a/src/test/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/PdfGenClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/PdfGenClientSpek.kt
@@ -39,7 +39,7 @@ class PdfGenClientSpek : Spek({
                 )
             }
 
-            pdf shouldBeEqualTo UserConstants.PDF_BEHANDLER
+            pdf shouldBeEqualTo UserConstants.PDF_BEHANDLER_MELDING
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjobSpek.kt
@@ -23,6 +23,7 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.io.StringReader
 import java.time.LocalDate
+import java.util.*
 import javax.xml.stream.XMLInputFactory
 
 class PublishMQCronjobSpek : Spek({
@@ -62,6 +63,9 @@ class PublishMQCronjobSpek : Spek({
                             fom = fom,
                             tom = tom,
                             callId = "callId",
+                            behandlerRef = UUID.randomUUID(),
+                            behandlerNavn = "Beate Behandler",
+                            behandlerDocument = generateDocumentComponent("En melding til behandler"),
                         )
                     }
                     val lagretVedtakBefore = database.getVedtak(vedtak.uuid)
@@ -79,7 +83,9 @@ class PublishMQCronjobSpek : Spek({
                     verify(exactly = 1) { mqSenderMock.sendToMQ(capture(queueNameSlot), capture(payloadSlot)) }
 
                     queueNameSlot.captured shouldBeEqualTo environment.mq.mqQueueName
-                    val message = JAXB.unmarshallObject<Infotrygd>(XMLInputFactory.newInstance().createXMLStreamReader(StringReader(payloadSlot.captured)))
+                    val message = JAXB.unmarshallObject<Infotrygd>(
+                        XMLInputFactory.newInstance().createXMLStreamReader(StringReader(payloadSlot.captured))
+                    )
                     message.header.brukerId shouldBeEqualTo UserConstants.VEILEDER_IDENT
                     message.header.fnr shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
                     message.meldingsspesFelt.meldingsdata.matsP1.datoFra.toString() shouldBeEqualTo fom.toString()

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
@@ -1,8 +1,7 @@
 package no.nav.syfo.infrastructure.database
 
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
-import no.nav.syfo.infrastructure.database.repository.PPdf
-import no.nav.syfo.infrastructure.database.repository.PVedtak
+import no.nav.syfo.infrastructure.database.repository.*
 import no.nav.syfo.infrastructure.database.repository.toPPdf
 import no.nav.syfo.infrastructure.database.repository.toPVedtak
 import org.flywaydb.core.Flyway
@@ -75,21 +74,32 @@ private const val queryGetVedtak =
         SELECT * FROM vedtak WHERE uuid = ?
     """
 
+private const val queryGetBehandlerMelding =
+    """
+        SELECT * FROM behandler_melding WHERE uuid = ?
+    """
+
 fun TestDatabase.getVedtak(
     vedtakUuid: UUID
-): PVedtak? = this.connection.use {
-        connection ->
+): PVedtak? = this.connection.use { connection ->
     connection.prepareStatement(queryGetVedtak).use {
         it.setString(1, vedtakUuid.toString())
         it.executeQuery().toList { toPVedtak() }.singleOrNull()
     }
 }
 
+fun TestDatabase.getBehandlerMelding(
+    behandlerMeldingUuid: UUID
+): PBehandlerMelding? =
+    this.connection.use { connection ->
+        connection.prepareStatement(queryGetBehandlerMelding).use {
+            it.setString(1, behandlerMeldingUuid.toString())
+            it.executeQuery().toList { toPBehandlerMelding() }.singleOrNull()
+        }
+    }
+
 class TestDatabaseNotResponding : DatabaseInterface {
 
     override val connection: Connection
         get() = throw Exception("Not working")
-
-    fun stop() {
-    }
 }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VedtakRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VedtakRepositorySpek.kt
@@ -1,0 +1,59 @@
+package no.nav.syfo.infrastructure.database
+
+import io.ktor.server.testing.*
+import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.UserConstants
+import no.nav.syfo.generator.generateBehandlerMelding
+import no.nav.syfo.generator.generateVedtak
+import no.nav.syfo.infrastructure.database.repository.VedtakRepository
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class VedtakRepositorySpek : Spek({
+
+    val vedtak = generateVedtak()
+    val behandlerMelding = generateBehandlerMelding()
+
+    describe(VedtakRepository::class.java.simpleName) {
+        with(TestApplicationEngine()) {
+            start()
+            val externalMockEnvironment = ExternalMockEnvironment.instance
+            val database = externalMockEnvironment.database
+            val vedtakRepository = VedtakRepository(database = database)
+
+            afterEachTest {
+                database.dropData()
+            }
+
+            it("Successfully creates a vedtak and behandlermelding") {
+
+                val (createdVedtak, createdBehandlerMelding) = vedtakRepository.createVedtak(
+                    vedtak = vedtak,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
+                )
+
+                val pVedtak = database.getVedtak(createdVedtak.uuid)
+                val pBehandlermelding = database.getBehandlerMelding(createdBehandlerMelding.uuid)
+
+                vedtak.uuid shouldBeEqualTo pVedtak?.uuid
+                vedtak.personident shouldBeEqualTo pVedtak?.personident
+                vedtak.veilederident shouldBeEqualTo pVedtak?.veilederident
+                vedtak.begrunnelse shouldBeEqualTo pVedtak?.begrunnelse
+                vedtak.document shouldBeEqualTo pVedtak?.document
+                vedtak.fom shouldBeEqualTo pVedtak?.fom
+                vedtak.tom shouldBeEqualTo pVedtak?.tom
+                vedtak.journalpostId shouldBeEqualTo pVedtak?.journalpostId
+
+                behandlerMelding.uuid shouldBeEqualTo pBehandlermelding?.uuid
+                behandlerMelding.behandlerRef shouldBeEqualTo pBehandlermelding?.behandlerRef
+                behandlerMelding.document shouldBeEqualTo pBehandlermelding?.document
+                behandlerMelding.journalpostId shouldBeEqualTo pBehandlermelding?.journalpostId
+
+                pBehandlermelding?.vedtakId shouldBeEqualTo pVedtak?.id
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdfGenMock.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdfGenMock.kt
@@ -12,8 +12,9 @@ fun MockRequestHandleScope.pdfGenMockResponse(request: HttpRequestData): HttpRes
         requestUrl.endsWith(PdfGenClient.Companion.VEDTAK_PATH) -> {
             respond(content = UserConstants.PDF_VEDTAK)
         }
+
         requestUrl.endsWith(PdfGenClient.Companion.MELDING_BEHANDLER_PATH) -> {
-            respond(content = UserConstants.PDF_BEHANDLER)
+            respond(content = UserConstants.PDF_BEHANDLER_MELDING)
         }
 
         else -> error("Unhandled pdf $requestUrl")


### PR DESCRIPTION
Legger til lagring av `BehandlerMelding`  som skal sendes ut til behandler når et §8-5 vedtak fattes.

- Ettersom en `BehandlerMelding` ikke kan eksistere uten et `Vedtak` lagres disse i samme `connection`. Ender da opp med å returnere et `Pair` fra `createVedtak` funksjonen. Jeg var litt frem og tilbake på om `BehandlerMelding` burde ha eget repository, men endte opp med denne løsningen. Si ifra om du har noen tanker 🙌
- Trenger også behandler navn for å lage pdf som skal sendes. Henter dette foreløpig fra frontend. Si ifra om du har forslag til alternativ løsning 🙌