### PR TITLE
IS-2210: Add esyfovarsel producer and kafka config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ object Version {
     const val LOGSTASH_ENCODER = "7.4"
     const val MICROMETER_REGISTRY = "1.12.2"
     const val JACKSON_DATATYPE = "2.16.1"
+    const val KAFKA = "3.7.0"
     const val KTOR = "2.3.8"
     const val MQ = "9.3.5.0"
     const val SPEK = "2.0.19"
@@ -69,6 +70,12 @@ dependencies {
 
     // MQ
     implementation("com.ibm.mq:com.ibm.mq.allclient:${Version.MQ}")
+
+    // Kafka
+    val excludeLog4j = fun ExternalModuleDependency.() {
+        exclude(group = "log4j")
+    }
+    implementation("org.apache.kafka:kafka_2.13:${Version.KAFKA}", excludeLog4j)
 
     // Tests
     testImplementation("io.ktor:ktor-server-tests:${Version.KTOR}")

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -20,7 +20,11 @@ import no.nav.syfo.infrastructure.database.repository.VedtakRepository
 import no.nav.syfo.infrastructure.infotrygd.InfotrygdService
 import no.nav.syfo.infrastructure.mq.MQSender
 import no.nav.syfo.infrastructure.journalforing.JournalforingService
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.EsyfovarselHendelseProducer
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.KafkaEsyfovarselHendelseSerializer
+import no.nav.syfo.infrastructure.kafka.kafkaAivenProducerConfig
 import no.nav.syfo.infrastructure.pdf.PdfService
+import org.apache.kafka.clients.producer.KafkaProducer
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
@@ -58,6 +62,11 @@ fun main() {
         mqQueueName = environment.mq.mqQueueName,
         mqSender = MQSender(environment.mq),
     )
+    val esyfovarselHendelseProducer = EsyfovarselHendelseProducer(
+        kafkaProducer = KafkaProducer(
+            kafkaAivenProducerConfig<KafkaEsyfovarselHendelseSerializer>(kafkaEnvironment = environment.kafka)
+        )
+    )
 
     lateinit var vedtakService: VedtakService
 
@@ -81,6 +90,7 @@ fun main() {
                         dokarkivClient = dokarkivClient,
                         pdlClient = pdlClient,
                     ),
+                    esyfovarselHendelseProducer = esyfovarselHendelseProducer,
                 )
                 apiModule(
                     applicationState = applicationState,

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.infrastructure.clients.ClientsEnvironment
 import no.nav.syfo.infrastructure.clients.OpenClientEnvironment
 import no.nav.syfo.infrastructure.clients.azuread.AzureEnvironment
 import no.nav.syfo.infrastructure.database.DatabaseEnvironment
+import no.nav.syfo.infrastructure.kafka.KafkaEnvironment
 import no.nav.syfo.infrastructure.mq.MQEnvironment
 
 const val NAIS_DATABASE_ENV_PREFIX = "NAIS_DATABASE_ISFRISKTILARBEID_ISFRISKTILARBEID_DB"
@@ -34,6 +35,13 @@ data class Environment(
             serviceuserUsername = getEnvVar("SERVICEUSER_USERNAME"),
             serviceuserPassword = getEnvVar("SERVICEUSER_PASSWORD"),
         ),
+    val kafka: KafkaEnvironment = KafkaEnvironment(
+        aivenBootstrapServers = getEnvVar("KAFKA_BROKERS"),
+        aivenCredstorePassword = getEnvVar("KAFKA_CREDSTORE_PASSWORD"),
+        aivenKeystoreLocation = getEnvVar("KAFKA_KEYSTORE_PATH"),
+        aivenSecurityProtocol = "SSL",
+        aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
+    ),
     val electorPath: String = getEnvVar("ELECTOR_PATH"),
     val clients: ClientsEnvironment =
         ClientsEnvironment(

--- a/src/main/kotlin/no/nav/syfo/application/IEsyfovarselHendelseProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IEsyfovarselHendelseProducer.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.application
+
+import no.nav.syfo.domain.Personident
+import no.nav.syfo.domain.Vedtak
+
+interface IEsyfovarselHendelseProducer {
+    fun sendVedtakVarsel(
+        personident: Personident,
+        vedtak: Vedtak
+    ): Result<Vedtak>
+}

--- a/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
@@ -13,6 +13,7 @@ class VedtakService(
     private val vedtakRepository: IVedtakRepository,
     private val journalforingService: IJournalforingService,
     private val infotrygdService: InfotrygdService,
+    private val esyfovarselHendelseProducer: IEsyfovarselHendelseProducer,
 ) {
     suspend fun createVedtak(
         personident: Personident,
@@ -82,5 +83,15 @@ class VedtakService(
                 journalfortVedtak
             }
         }
+    }
+
+    fun publishVedtakVarsel(
+        personident: Personident,
+        vedtak: Vedtak
+    ): Result<Vedtak> {
+        return esyfovarselHendelseProducer.sendVedtakVarsel(
+            personident = personident,
+            vedtak = vedtak
+        )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConfig.kt
@@ -1,0 +1,39 @@
+package no.nav.syfo.infrastructure.kafka
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.serialization.StringSerializer
+import java.util.*
+
+inline fun <reified Serializer> kafkaAivenProducerConfig(
+    kafkaEnvironment: KafkaEnvironment,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenConfig(kafkaEnvironment))
+        this[ProducerConfig.ACKS_CONFIG] = "all"
+        this[ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG] = "true"
+        this[ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION] = "1"
+        this[ProducerConfig.MAX_BLOCK_MS_CONFIG] = "15000"
+        this[ProducerConfig.RETRIES_CONFIG] = "100000"
+        this[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java.canonicalName
+        this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = Serializer::class.java.canonicalName
+    }
+}
+
+fun commonKafkaAivenConfig(
+    kafkaEnvironment: KafkaEnvironment,
+) = Properties().apply {
+    this[SaslConfigs.SASL_MECHANISM] = "PLAIN"
+    this[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = kafkaEnvironment.aivenBootstrapServers
+    this[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = kafkaEnvironment.aivenSecurityProtocol
+    this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = ""
+    this[SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG] = "jks"
+    this[SslConfigs.SSL_KEYSTORE_TYPE_CONFIG] = "PKCS12"
+    this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = kafkaEnvironment.aivenTruststoreLocation
+    this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
+    this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = kafkaEnvironment.aivenKeystoreLocation
+    this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
+    this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaEnvironment.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.infrastructure.kafka
+
+class KafkaEnvironment(
+    val aivenKeystoreLocation: String,
+    val aivenCredstorePassword: String,
+    val aivenTruststoreLocation: String,
+    val aivenSecurityProtocol: String,
+    val aivenBootstrapServers: String,
+)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/EsyfovarselHendelseProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/EsyfovarselHendelseProducer.kt
@@ -1,0 +1,54 @@
+package no.nav.syfo.infrastructure.kafka.esyfovarsel
+
+import no.nav.syfo.application.IEsyfovarselHendelseProducer
+import no.nav.syfo.domain.Personident
+import no.nav.syfo.domain.Vedtak
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.*
+import java.util.*
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+
+class EsyfovarselHendelseProducer(
+    private val kafkaProducer: KafkaProducer<String, EsyfovarselHendelse>,
+) : IEsyfovarselHendelseProducer {
+
+    override fun sendVedtakVarsel(
+        personident: Personident,
+        vedtak: Vedtak,
+    ): Result<Vedtak> {
+        if (vedtak.journalpostId == null)
+            throw IllegalStateException("JournalpostId is null for vedtak ${vedtak.uuid}")
+
+        val varselHendelse = ArbeidstakerHendelse(
+            type = HendelseType.SM_VEDTAK_FRISKMELDING_TIL_ARBEIDSFORMIDLING,
+            arbeidstakerFnr = personident.value,
+            data = VarselData(
+                journalpost = VarselDataJournalpost(
+                    uuid = vedtak.uuid.toString(),
+                    id = vedtak.journalpostId.value,
+                ),
+            ),
+            orgnummer = null,
+        )
+
+        return try {
+            kafkaProducer.send(
+                ProducerRecord(
+                    ESYFOVARSEL_TOPIC,
+                    UUID.nameUUIDFromBytes(personident.value.toByteArray()).toString(),
+                    varselHendelse,
+                )
+            ).get()
+            Result.success(vedtak)
+        } catch (e: Exception) {
+            log.error("Exception was thrown when attempting to send hendelse vedtak (uuid: ${vedtak.uuid}) to esyfovarsel: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    companion object {
+        private const val ESYFOVARSEL_TOPIC = "team-esyfo.varselbus"
+        private val log = LoggerFactory.getLogger(EsyfovarselHendelseProducer::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/KafkaEsyfovarselHendelseSerializer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/KafkaEsyfovarselHendelseSerializer.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.infrastructure.kafka.esyfovarsel
+
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.EsyfovarselHendelse
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.common.serialization.Serializer
+
+class KafkaEsyfovarselHendelseSerializer : Serializer<EsyfovarselHendelse> {
+    private val mapper = configuredJacksonMapper()
+    override fun serialize(topic: String?, data: EsyfovarselHendelse?): ByteArray =
+        mapper.writeValueAsBytes(data)
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/dto/EsyfovarselHendelse.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/dto/EsyfovarselHendelse.kt
@@ -1,0 +1,30 @@
+package no.nav.syfo.infrastructure.kafka.esyfovarsel.dto
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import java.io.Serializable
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+sealed interface EsyfovarselHendelse : Serializable {
+    val type: HendelseType
+    var data: Any?
+}
+
+data class ArbeidstakerHendelse(
+    override val type: HendelseType,
+    override var data: Any?,
+    val arbeidstakerFnr: String,
+    val orgnummer: String?
+) : EsyfovarselHendelse
+
+data class VarselData(
+    val journalpost: VarselDataJournalpost? = null,
+)
+
+data class VarselDataJournalpost(
+    val uuid: String,
+    val id: String?
+)
+
+enum class HendelseType {
+    SM_VEDTAK_FRISKMELDING_TIL_ARBEIDSFORMIDLING,
+}

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.infrastructure.clients.ClientsEnvironment
 import no.nav.syfo.infrastructure.clients.OpenClientEnvironment
 import no.nav.syfo.infrastructure.clients.azuread.AzureEnvironment
 import no.nav.syfo.infrastructure.database.DatabaseEnvironment
+import no.nav.syfo.infrastructure.kafka.KafkaEnvironment
 import no.nav.syfo.infrastructure.mq.MQEnvironment
 
 fun testEnvironment() = Environment(
@@ -46,6 +47,13 @@ fun testEnvironment() = Environment(
         mqQueueName = "mqQueueName",
         serviceuserUsername = "serviceuser",
         serviceuserPassword = "servicepw",
+    ),
+    kafka = KafkaEnvironment(
+        aivenBootstrapServers = "kafkaBootstrapServers",
+        aivenCredstorePassword = "credstorepassord",
+        aivenKeystoreLocation = "keystore",
+        aivenSecurityProtocol = "SSL",
+        aivenTruststoreLocation = "truststore",
     ),
     electorPath = "electorPath",
 )

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.api
 import io.ktor.server.application.*
 import io.mockk.mockk
 import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.application.IEsyfovarselHendelseProducer
 import no.nav.syfo.application.VedtakService
 import no.nav.syfo.infrastructure.mq.MQSender
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
@@ -36,6 +37,7 @@ fun Application.testApiModule(
             mqQueueName = externalMockEnvironment.environment.mq.mqQueueName,
             mqSender = mockk<MQSender>(relaxed = true),
         ),
+        esyfovarselHendelseProducer = mockk<IEsyfovarselHendelseProducer>(relaxed = true),
     )
 
     this.apiModule(

--- a/src/test/kotlin/no/nav/syfo/application/VedtakServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/VedtakServiceSpek.kt
@@ -11,12 +11,15 @@ import no.nav.syfo.infrastructure.database.getVedtak
 import no.nav.syfo.infrastructure.database.repository.VedtakRepository
 import no.nav.syfo.infrastructure.infotrygd.InfotrygdService
 import no.nav.syfo.infrastructure.journalforing.JournalforingService
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.EsyfovarselHendelseProducer
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.EsyfovarselHendelse
 import no.nav.syfo.infrastructure.mock.mockedJournalpostId
 import no.nav.syfo.infrastructure.mq.MQSender
 import no.nav.syfo.infrastructure.pdf.PdfService
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterThan
+import org.apache.kafka.clients.producer.KafkaProducer
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -35,6 +38,10 @@ class VedtakServiceSpek : Spek({
             pdlClient = externalMockEnvironment.pdlClient,
         )
         val vedtakRepository = VedtakRepository(database = database)
+        val mockProducer = mockk<KafkaProducer<String, EsyfovarselHendelse>>()
+        val esyfovarselHendelseProducer = EsyfovarselHendelseProducer(
+            kafkaProducer = mockProducer,
+        )
         val vedtakService = VedtakService(
             vedtakRepository = vedtakRepository,
             pdfService = PdfService(
@@ -45,7 +52,9 @@ class VedtakServiceSpek : Spek({
             infotrygdService = InfotrygdService(
                 mqQueueName = externalMockEnvironment.environment.mq.mqQueueName,
                 mqSender = mockk<MQSender>(relaxed = true),
-            )
+            ),
+            esyfovarselHendelseProducer = esyfovarselHendelseProducer,
+
         )
 
         afterEachTest {

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjobSpek.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.runBlocking
 import no.aetat.arena.arenainfotrygdskjema.Infotrygd
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
+import no.nav.syfo.application.IEsyfovarselHendelseProducer
 import no.nav.syfo.application.VedtakService
 import no.nav.syfo.generator.generateDocumentComponent
 import no.nav.syfo.infrastructure.database.dropData
@@ -39,7 +40,8 @@ class PublishMQCronjobSpek : Spek({
                 pdfService = PdfService(externalMockEnvironment.pdfgenClient, externalMockEnvironment.pdlClient),
                 vedtakRepository = VedtakRepository(database),
                 journalforingService = mockk<JournalforingService>(relaxed = true),
-                infotrygdService = InfotrygdService(environment.mq.mqQueueName, mqSenderMock)
+                infotrygdService = InfotrygdService(environment.mq.mqQueueName, mqSenderMock),
+                esyfovarselHendelseProducer = mockk<IEsyfovarselHendelseProducer>(relaxed = true),
             )
 
             val publishMQCronjob = PublishMQCronjob(vedtakService)


### PR DESCRIPTION
Første del av å legge til varsling via esyfovarsel.
Se også PR i esyfovarsel: https://github.com/navikt/esyfovarsel/pull/472

Neste blir å legge til felt i databasen for publisering, og cronjob som kaller funksjonen i servicen samt oppdaterer databasen hvis noe ble publisert.