### PR TITLE
IS-2210: Publish vedtak-varsel in cronjob

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/IEsyfovarselHendelseProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IEsyfovarselHendelseProducer.kt
@@ -1,11 +1,7 @@
 package no.nav.syfo.application
 
-import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Vedtak
 
 interface IEsyfovarselHendelseProducer {
-    fun sendVedtakVarsel(
-        personident: Personident,
-        vedtak: Vedtak
-    ): Result<Vedtak>
+    fun sendVedtakVarsel(vedtak: Vedtak): Result<Vedtak>
 }

--- a/src/main/kotlin/no/nav/syfo/application/IVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVedtakRepository.kt
@@ -18,4 +18,6 @@ interface IVedtakRepository {
     fun getNotJournalforteVedtak(): List<Pair<Vedtak, ByteArray>>
 
     fun update(vedtak: Vedtak)
+
+    fun getUnpublishedVedtakVarsler(): List<Vedtak>
 }

--- a/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
@@ -85,13 +85,15 @@ class VedtakService(
         }
     }
 
-    fun publishVedtakVarsel(
-        personident: Personident,
-        vedtak: Vedtak
-    ): Result<Vedtak> {
-        return esyfovarselHendelseProducer.sendVedtakVarsel(
-            personident = personident,
-            vedtak = vedtak
-        )
+    fun publishVedtakVarsel(): List<Result<Vedtak>> {
+        val unpublishedVedtakVarsler = vedtakRepository.getUnpublishedVedtakVarsler()
+        return unpublishedVedtakVarsler.map { vedtak ->
+            val result = esyfovarselHendelseProducer.sendVedtakVarsel(vedtak)
+            result.map {
+                val publishedVedtakVarsel = vedtak.publishVarsel()
+                vedtakRepository.update(publishedVedtakVarsel)
+                publishedVedtakVarsel
+            }
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/domain/Vedtak.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vedtak.kt
@@ -15,6 +15,7 @@ data class Vedtak private constructor(
     val fom: LocalDate,
     val tom: LocalDate,
     val journalpostId: JournalpostId?,
+    val varselPublishedAt: OffsetDateTime?,
 ) {
     constructor(
         personident: Personident,
@@ -33,9 +34,12 @@ data class Vedtak private constructor(
         fom = fom,
         tom = tom,
         journalpostId = null,
+        varselPublishedAt = null,
     )
 
     fun journalfor(journalpostId: JournalpostId): Vedtak = this.copy(journalpostId = journalpostId)
+
+    fun publishVarsel(): Vedtak = this.copy(varselPublishedAt = nowUTC())
 
     companion object {
 
@@ -49,6 +53,7 @@ data class Vedtak private constructor(
             fom: LocalDate,
             tom: LocalDate,
             journalpostId: JournalpostId?,
+            varselPublishedAt: OffsetDateTime?,
         ) = Vedtak(
             uuid = uuid,
             personident = personident,
@@ -59,6 +64,7 @@ data class Vedtak private constructor(
             fom = fom,
             tom = tom,
             journalpostId = journalpostId,
+            varselPublishedAt = varselPublishedAt,
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -26,6 +26,9 @@ fun launchCronjobs(
     val journalforVedtakCronjob = JournalforVedtakCronjob(vedtakService = vedtakService)
     cronjobs.add(journalforVedtakCronjob)
 
+    val publishVedtakVarselCronjob = PublishVedtakVarselCronjob(vedtakService = vedtakService)
+    cronjobs.add(publishVedtakVarselCronjob)
+
     cronjobs.forEach {
         launchBackgroundTask(
             applicationState = applicationState,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/PublishVedtakVarselCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/PublishVedtakVarselCronjob.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import no.nav.syfo.application.VedtakService
+
+class PublishVedtakVarselCronjob(
+    private val vedtakService: VedtakService,
+) : Cronjob {
+
+    override val initialDelayMinutes: Long = 4
+    override val intervalDelayMinutes: Long = 10
+
+    override suspend fun run(): List<Result<Any>> = vedtakService.publishVedtakVarsel()
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVedtak.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVedtak.kt
@@ -22,6 +22,7 @@ data class PVedtak(
     val journalpostId: String?,
     val pdfId: Int,
     val publishedInfotrygdAt: OffsetDateTime?,
+    val varselPublishedAt: OffsetDateTime?,
 ) {
     fun toVedtak(): Vedtak = Vedtak.createFromDatabase(
         uuid = uuid,
@@ -33,5 +34,6 @@ data class PVedtak(
         fom = fom,
         tom = tom,
         journalpostId = journalpostId?.let { JournalpostId(it) },
+        varselPublishedAt = varselPublishedAt,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/EsyfovarselHendelseProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/EsyfovarselHendelseProducer.kt
@@ -1,28 +1,24 @@
 package no.nav.syfo.infrastructure.kafka.esyfovarsel
 
 import no.nav.syfo.application.IEsyfovarselHendelseProducer
-import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Vedtak
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.*
-import java.util.*
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
+import java.util.*
 
 class EsyfovarselHendelseProducer(
     private val kafkaProducer: KafkaProducer<String, EsyfovarselHendelse>,
 ) : IEsyfovarselHendelseProducer {
 
-    override fun sendVedtakVarsel(
-        personident: Personident,
-        vedtak: Vedtak,
-    ): Result<Vedtak> {
+    override fun sendVedtakVarsel(vedtak: Vedtak): Result<Vedtak> {
         if (vedtak.journalpostId == null)
             throw IllegalStateException("JournalpostId is null for vedtak ${vedtak.uuid}")
 
         val varselHendelse = ArbeidstakerHendelse(
             type = HendelseType.SM_VEDTAK_FRISKMELDING_TIL_ARBEIDSFORMIDLING,
-            arbeidstakerFnr = personident.value,
+            arbeidstakerFnr = vedtak.personident.value,
             data = VarselData(
                 journalpost = VarselDataJournalpost(
                     uuid = vedtak.uuid.toString(),
@@ -36,7 +32,7 @@ class EsyfovarselHendelseProducer(
             kafkaProducer.send(
                 ProducerRecord(
                     ESYFOVARSEL_TOPIC,
-                    UUID.nameUUIDFromBytes(personident.value.toByteArray()).toString(),
+                    UUID.nameUUIDFromBytes(vedtak.personident.value.toByteArray()).toString(),
                     varselHendelse,
                 )
             ).get()

--- a/src/main/resources/db/migration/V1_5__add_column_varsel_published_at.sql
+++ b/src/main/resources/db/migration/V1_5__add_column_varsel_published_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE VEDTAK ADD COLUMN varsel_published_at timestamptz;

--- a/src/test/kotlin/no/nav/syfo/application/VedtakServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/VedtakServiceSpek.kt
@@ -1,9 +1,11 @@
 package no.nav.syfo.application
 
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
+import no.nav.syfo.domain.JournalpostId
+import no.nav.syfo.domain.Vedtak
 import no.nav.syfo.generator.generateBehandlerMelding
 import no.nav.syfo.generator.generateVedtak
 import no.nav.syfo.infrastructure.database.dropData
@@ -12,20 +14,29 @@ import no.nav.syfo.infrastructure.database.repository.VedtakRepository
 import no.nav.syfo.infrastructure.infotrygd.InfotrygdService
 import no.nav.syfo.infrastructure.journalforing.JournalforingService
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.EsyfovarselHendelseProducer
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.ArbeidstakerHendelse
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.EsyfovarselHendelse
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.HendelseType
+import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.VarselData
 import no.nav.syfo.infrastructure.mock.mockedJournalpostId
 import no.nav.syfo.infrastructure.mq.MQSender
 import no.nav.syfo.infrastructure.pdf.PdfService
+import no.nav.syfo.util.nowUTC
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldNotBeNull
 import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.util.concurrent.Future
 
 val vedtak = generateVedtak()
 val behandlerMelding = generateBehandlerMelding()
 val otherBehandlerMelding = generateBehandlerMelding()
+val journalpostId = JournalpostId("123")
 
 class VedtakServiceSpek : Spek({
     describe(VedtakService::class.java.simpleName) {
@@ -56,6 +67,11 @@ class VedtakServiceSpek : Spek({
             esyfovarselHendelseProducer = esyfovarselHendelseProducer,
 
         )
+
+        beforeEachTest {
+            clearAllMocks()
+            coEvery { mockProducer.send(any()) } returns mockk<Future<RecordMetadata>>(relaxed = true)
+        }
 
         afterEachTest {
             database.dropData()
@@ -161,6 +177,87 @@ class VedtakServiceSpek : Spek({
 
                 failed.size shouldBeEqualTo 1
                 success.size shouldBeEqualTo 1
+            }
+        }
+
+        describe("Publish varsel for vedtak to esyfovarsel") {
+            fun createUnpublishedVedtakVarsel(): Vedtak {
+                val unpublishedVedtakVarsel = vedtakRepository.createVedtak(
+                    vedtak = vedtak,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
+                ).first
+                vedtakRepository.update(unpublishedVedtakVarsel.copy(journalpostId = journalpostId))
+                return unpublishedVedtakVarsel
+            }
+
+            it("Publishes varsel for vedtak") {
+                val unpublishedVedtakVarsel = createUnpublishedVedtakVarsel()
+
+                val (success, failed) = vedtakService.publishVedtakVarsel().partition { it.isSuccess }
+
+                failed.size shouldBeEqualTo 0
+                success.size shouldBeEqualTo 1
+
+                val producerRecordSlot = slot<ProducerRecord<String, EsyfovarselHendelse>>()
+                verify(exactly = 1) { mockProducer.send(capture(producerRecordSlot)) }
+
+                val publishedVedtakVarsel = success.first().getOrThrow()
+                publishedVedtakVarsel.uuid.shouldBeEqualTo(unpublishedVedtakVarsel.uuid)
+                publishedVedtakVarsel.varselPublishedAt.shouldNotBeNull()
+
+                val esyfovarselHendelse = producerRecordSlot.captured.value() as ArbeidstakerHendelse
+                esyfovarselHendelse.type shouldBeEqualTo HendelseType.SM_VEDTAK_FRISKMELDING_TIL_ARBEIDSFORMIDLING
+                esyfovarselHendelse.arbeidstakerFnr shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
+                val varselData = esyfovarselHendelse.data as VarselData
+                varselData.journalpost?.uuid shouldBeEqualTo publishedVedtakVarsel.uuid.toString()
+                varselData.journalpost?.id!! shouldBeEqualTo journalpostId.value
+            }
+
+            it("Publishes nothing when no vedtak") {
+                val (success, failed) = vedtakService.publishVedtakVarsel().partition { it.isSuccess }
+
+                failed.size shouldBeEqualTo 0
+                success.size shouldBeEqualTo 0
+            }
+
+            it("Publishes nothing when no journalfort vedtak") {
+                vedtakRepository.createVedtak(
+                    vedtak = vedtak,
+                    vedtakPdf = UserConstants.PDF_VEDTAK,
+                    behandlerMelding = behandlerMelding,
+                    behandlerMeldingPdf = UserConstants.PDF_BEHANDLER_MELDING,
+                )
+
+                val (success, failed) = vedtakService.publishVedtakVarsel().partition { it.isSuccess }
+
+                failed.size shouldBeEqualTo 0
+                success.size shouldBeEqualTo 0
+            }
+
+            it("Publishes nothing when varsel for vedtak already published") {
+                val publishedVedtakVarsel = createUnpublishedVedtakVarsel().copy(varselPublishedAt = nowUTC())
+                vedtakRepository.update(publishedVedtakVarsel)
+
+                val (success, failed) = vedtakService.publishVedtakVarsel().partition { it.isSuccess }
+
+                failed.size shouldBeEqualTo 0
+                success.size shouldBeEqualTo 0
+            }
+
+            it("Fails publishing when kafka-producer fails") {
+                val unpublishedVedtak = createUnpublishedVedtakVarsel()
+                every { mockProducer.send(any()) } throws Exception("Error producing to kafka")
+
+                val (success, failed) = vedtakService.publishVedtakVarsel().partition { it.isSuccess }
+                failed.size shouldBeEqualTo 1
+                success.size shouldBeEqualTo 0
+
+                verify(exactly = 1) { mockProducer.send(any()) }
+
+                val vedtak = vedtakRepository.getUnpublishedVedtakVarsler().first()
+                vedtak.uuid shouldBeEqualTo unpublishedVedtak.uuid
             }
         }
     }


### PR DESCRIPTION
Tar gjerne litt innspill på navn her. Har ikke laget en egen `Varsel`-klasse her. Er varsel fortsatt en domenespesifikk greie da, eller burde vi kalle det notification? `UnpublishedVedtakVarsel` er langt, men å kalle det `UnpublishedVarsel` er jo litt upresist. Vi kan bruke `UnpublishedVedtak`, men da kan det kanskje blandes med om vedtaket er publisert på vår fremtidige vedtak-kafka, ikke varslingskafka 🤷🏼‍♂️