### PR TITLE
IS-2258: Setup journalfor behandlermelding cronjob

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -75,6 +75,10 @@ fun main() {
             kafkaAivenProducerConfig<BehandlermeldingRecordSerializer>(kafkaEnvironment = environment.kafka)
         )
     )
+    val journalforingService = JournalforingService(
+        dokarkivClient = dokarkivClient,
+        pdlClient = pdlClient,
+    )
 
     lateinit var vedtakService: VedtakService
 
@@ -94,10 +98,7 @@ fun main() {
                     pdfService = pdfService,
                     vedtakRepository = vedtakRepository,
                     infotrygdService = infotrygdService,
-                    journalforingService = JournalforingService(
-                        dokarkivClient = dokarkivClient,
-                        pdlClient = pdlClient,
-                    ),
+                    journalforingService = journalforingService,
                     esyfovarselHendelseProducer = esyfovarselHendelseProducer,
                 )
                 apiModule(
@@ -118,6 +119,7 @@ fun main() {
         val behandlermeldingService = BehandlermeldingService(
             behandlermeldingRepository = BehandlermeldingRepository(database = applicationDatabase),
             behandlermeldingProducer = behandlermeldingProducer,
+            journalforingService = journalforingService,
         )
 
         launchCronjobs(

--- a/src/main/kotlin/no/nav/syfo/application/BehandlermeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/BehandlermeldingService.kt
@@ -2,7 +2,12 @@ package no.nav.syfo.application
 
 import no.nav.syfo.domain.Behandlermelding
 
-class BehandlermeldingService(private val behandlermeldingRepository: IBehandlermeldingRepository, private val behandlermeldingProducer: IBehandlermeldingProducer) {
+class BehandlermeldingService(
+    private val behandlermeldingRepository: IBehandlermeldingRepository,
+    private val behandlermeldingProducer: IBehandlermeldingProducer,
+    private val journalforingService: IJournalforingService,
+) {
+
     fun publishBehandlermeldinger(): List<Result<Behandlermelding>> {
         val unpublished = behandlermeldingRepository.getUnpublishedBehandlermeldinger()
 
@@ -12,6 +17,23 @@ class BehandlermeldingService(private val behandlermeldingRepository: IBehandler
                 val publishedBehandlermelding = it.publish()
                 behandlermeldingRepository.update(publishedBehandlermelding)
                 publishedBehandlermelding
+            }
+        }
+    }
+
+    suspend fun journalforBehandlermeldinger(): List<Result<Behandlermelding>> {
+        val notJournalforteBehandlermeldinger = behandlermeldingRepository.getNotJournalforteBehandlermeldinger()
+
+        return notJournalforteBehandlermeldinger.map { (personident, behandlermelding, pdf) ->
+            journalforingService.journalfor(
+                personident = personident,
+                behandlermelding = behandlermelding,
+                pdf = pdf,
+            ).map {
+                val journalfortBehandlermelding = behandlermelding.journalfor(journalpostId = it)
+                behandlermeldingRepository.update(journalfortBehandlermelding)
+
+                journalfortBehandlermelding
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/application/IBehandlermeldingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IBehandlermeldingRepository.kt
@@ -6,4 +6,5 @@ import no.nav.syfo.domain.Personident
 interface IBehandlermeldingRepository {
     fun getUnpublishedBehandlermeldinger(): List<Triple<Personident, Behandlermelding, ByteArray>>
     fun update(behandlermelding: Behandlermelding)
+    fun getNotJournalforteBehandlermeldinger(): List<Triple<Personident, Behandlermelding, ByteArray>>
 }

--- a/src/main/kotlin/no/nav/syfo/application/IJournalforingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IJournalforingService.kt
@@ -1,11 +1,19 @@
 package no.nav.syfo.application
 
+import no.nav.syfo.domain.Behandlermelding
 import no.nav.syfo.domain.JournalpostId
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Vedtak
 
 interface IJournalforingService {
     suspend fun journalfor(
         vedtak: Vedtak,
         pdf: ByteArray,
+    ): Result<JournalpostId>
+
+    suspend fun journalfor(
+        personident: Personident,
+        behandlermelding: Behandlermelding,
+        pdf: ByteArray
     ): Result<JournalpostId>
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -28,6 +28,10 @@ fun launchCronjobs(
     val journalforVedtakCronjob = JournalforVedtakCronjob(vedtakService = vedtakService)
     cronjobs.add(journalforVedtakCronjob)
 
+    val journalforBehandlermeldingCronjob =
+        JournalforBehandlermeldingCronjob(behandlermeldingService = behandlermeldingService)
+    cronjobs.add(journalforBehandlermeldingCronjob)
+
     val publishVedtakVarselCronjob = PublishVedtakVarselCronjob(vedtakService = vedtakService)
     cronjobs.add(publishVedtakVarselCronjob)
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/JournalforBehandlermeldingCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/JournalforBehandlermeldingCronjob.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import no.nav.syfo.application.BehandlermeldingService
+
+class JournalforBehandlermeldingCronjob(private val behandlermeldingService: BehandlermeldingService) : Cronjob {
+
+    override val initialDelayMinutes: Long = 4
+    override val intervalDelayMinutes: Long = 10
+
+    override suspend fun run() = behandlermeldingService.journalforBehandlermeldinger()
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
@@ -20,6 +20,10 @@ class JournalforingService(private val dokarkivClient: DokarkivClient, private v
         JournalpostId(journalpostId.toString())
     }
 
+    override suspend fun journalfor(personident: Personident, behandlermelding: Behandlermelding, pdf: ByteArray): Result<JournalpostId> {
+        TODO("Not yet implemented")
+    }
+
     private fun createJournalpostRequest(
         vedtak: Vedtak,
         navn: String,


### PR DESCRIPTION
Oppsett for å kunne journalføre behandlermeldinger i cronjob. Selve journalforingen i journalforingService er ikke implementert enda - her trengs bl.a. kode for å hente navn og personident til behandler fra isdialogmelding.