### PR TITLE
IS-2250: Add setup for vedtak fattet kafka producer

### DIFF
--- a/.github/workflows/kafka-frisktilarbeid.yaml
+++ b/.github/workflows/kafka-frisktilarbeid.yaml
@@ -1,0 +1,41 @@
+name: kafka
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/kafka-frisktilarbeid.yaml'
+      - '.nais/kafka/**'
+
+permissions:
+  id-token: write
+
+jobs:
+  deploy-kafka-frisktilarbeid-dev:
+    name: Deploy Kafka topics to dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy isfrisktilarbeid-vedtak-fattet topic to dev
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/kafka/isfrisktilarbeid-vedtak-fattet.yaml
+          VARS: .nais/kafka/dev.json
+
+
+  deploy-kafka-frisktilarbeid-prod:
+    name: Deploy Kafka topics to prod-gcp
+    needs: deploy-kafka-frisktilarbeid-dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy isfrisktilarbeid-vedtak-fattet topic to prod
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/kafka/isfrisktilarbeid-vedtak-fattet.yaml
+          VARS: .nais/kafka/prod.json

--- a/.nais/kafka/dev.json
+++ b/.nais/kafka/dev.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-dev"
+}

--- a/.nais/kafka/isfrisktilarbeid-vedtak-fattet.yaml
+++ b/.nais/kafka/isfrisktilarbeid-vedtak-fattet.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  annotations:
+    dcat.data.nav.no/title: "Vedtak relatert til friskmelding til arbeidsformidling for sykmeldte personer"
+    dcat.data.nav.no/description: >-
+      Topic inneholder informasjon om vedtak relatert til friskmelding til arbeidsformidling for sykmeldte personer.
+  name: isfrisktilarbeid-vedtak-fattet
+  namespace: teamsykefravr
+  labels:
+    team: teamsykefravr
+spec:
+  pool: {{ kafkaPool }}
+  config:
+    cleanupPolicy: delete
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: -1  # -1 means unlimited
+  acl:
+    - team: teamsykefravr
+      application: isfrisktilarbeid
+      access: readwrite
+    - team: disykefravar
+      application: dvh-sykefravar-airflow-kafka
+      access: read

--- a/.nais/kafka/prod.json
+++ b/.nais/kafka/prod.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-prod"
+}

--- a/src/main/kotlin/no/nav/syfo/application/IVedtakFattetProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVedtakFattetProducer.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.application
+
+import no.nav.syfo.domain.Vedtak
+
+interface IVedtakFattetProducer {
+    fun send(vedtak: Vedtak): Result<Vedtak>
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VedtakFattetProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VedtakFattetProducer.kt
@@ -1,0 +1,56 @@
+package no.nav.syfo.infrastructure.kafka
+
+import no.nav.syfo.application.IVedtakFattetProducer
+import no.nav.syfo.domain.Personident
+import no.nav.syfo.domain.Vedtak
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.*
+
+data class VedtakFattetRecord(
+    val uuid: UUID,
+    val personident: Personident,
+    val veilederident: String,
+    val createdAt: OffsetDateTime,
+    val begrunnelse: String,
+    val fom: LocalDate,
+    val tom: LocalDate,
+)
+
+class VedtakFattetProducer(
+    private val producer: KafkaProducer<String, VedtakFattetRecord>,
+) : IVedtakFattetProducer {
+
+    override fun send(
+        vedtak: Vedtak,
+    ): Result<Vedtak> =
+        try {
+            producer.send(
+                ProducerRecord(
+                    TOPIC,
+                    UUID.randomUUID().toString(),
+                    VedtakFattetRecord(
+                        uuid = vedtak.uuid,
+                        personident = vedtak.personident,
+                        veilederident = vedtak.veilederident,
+                        createdAt = vedtak.createdAt,
+                        begrunnelse = vedtak.begrunnelse,
+                        fom = vedtak.fom,
+                        tom = vedtak.tom,
+                    )
+                )
+            ).get()
+            Result.success(vedtak)
+        } catch (e: Exception) {
+            log.error("Exception was thrown when attempting to publish fattet vedtak: ${e.message}")
+            Result.failure(e)
+        }
+
+    companion object {
+        private const val TOPIC = "teamsykefravr.isfrisktilarbeid-vedtak-fattet"
+        private val log = LoggerFactory.getLogger(VedtakFattetProducer::class.java)
+    }
+}


### PR DESCRIPTION
Vanskelig med navn her! 
Anders og jeg snakket om at vi kanskje på sikt vil ha et topic som sier når vedtaket faktisk startet, feks til flex. Derfor slang jeg på en `vedtak-fattet`. Eller `fattet-vedtak` 🤔

Og så er topicet bare koblet til namespacet og ikke appen i navnet, så måtte slenge på `friskmelding-til-arbeidsformidling` foran slik at det ble eksplisitt. Men bare å komme med tilbakemelding på det også.

Neste PR blir å implementere publiseringen ved opprettelse av vedtak.