### PR TITLE
IS-2436: Log number of failed and successful fatt vedtak requests

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/VedtakEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/VedtakEndpoints.kt
@@ -11,6 +11,8 @@ import no.nav.syfo.application.VedtakService
 import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollPlugin
+import no.nav.syfo.infrastructure.metric.COUNT_FATT_VEDTAK_FAILURE
+import no.nav.syfo.infrastructure.metric.COUNT_FATT_VEDTAK_SUCCESS
 import no.nav.syfo.util.getCallId
 import no.nav.syfo.util.getNAVIdent
 import no.nav.syfo.util.getPersonident
@@ -57,6 +59,7 @@ fun Route.registerVedtakEndpoints(
 
             if (vedtakService.getVedtak(personident).any { !it.isFerdigbehandlet() }) {
                 call.respond(HttpStatusCode.Conflict, "Finnes allerede et åpent vedtak for personen")
+                COUNT_FATT_VEDTAK_FAILURE.increment()
             } else {
                 val newVedtak = vedtakService.createVedtak(
                     personident = personident,
@@ -69,6 +72,7 @@ fun Route.registerVedtakEndpoints(
                 )
 
                 call.respond(HttpStatusCode.Created, VedtakResponseDTO.createFromVedtak(vedtak = newVedtak))
+                COUNT_FATT_VEDTAK_SUCCESS.increment()
             }
         }
         put(ferdigbehandlingPath) {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/metric/Metric.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/metric/Metric.kt
@@ -1,8 +1,18 @@
 package no.nav.syfo.infrastructure.metric
 
+import io.micrometer.core.instrument.Counter
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
 
 const val METRICS_NS = "isfrisktilarbeid"
 
 val METRICS_REGISTRY = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+private const val VEDTAK_FATTET = "${METRICS_NS}_fatt_vedtak"
+
+val COUNT_FATT_VEDTAK_SUCCESS = Counter.builder("${VEDTAK_FATTET}_success_count")
+    .description("Counts the number of successful calls to /api/internad/v1/frisktilarbeid/vedtak")
+    .register(METRICS_REGISTRY)
+val COUNT_FATT_VEDTAK_FAILURE = Counter.builder("${VEDTAK_FATTET}_failure_count")
+    .description("Counts the number of failed calls to /api/internad/v1/frisktilarbeid/vedtak")
+    .register(METRICS_REGISTRY)


### PR DESCRIPTION
Legger til at vi teller antall suksessfulle og feilede kall for å fatte 8-5 vedtak