### PR TITLE
Resend failed message to Infotrygd

### DIFF
--- a/src/main/resources/db/migration/V2_1__resend_infotrygd_message.sql
+++ b/src/main/resources/db/migration/V2_1__resend_infotrygd_message.sql
@@ -1,0 +1,1 @@
+UPDATE VEDTAK SET published_infotrygd_at=null WHERE uuid='4342b0ad-f517-41e9-9c61-cb07f922a3e8';


### PR DESCRIPTION
For å feilsøke vil Infotrygd at vi skal forsøke å resende en av meldingene som vi ikke fikk kvittering for.

NB! Merges etter nærmere avtale med Infotrygd