### PR TITLE
IS-2660: Add infotrygd status to vedtak

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/model/VedtakResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/VedtakResponseDTO.kt
@@ -17,6 +17,7 @@ data class VedtakResponseDTO private constructor(
     val document: List<DocumentComponent>,
     val ferdigbehandletAt: LocalDateTime?,
     val ferdigbehandletBy: String?,
+    val infotrygdStatus: String,
 ) {
     companion object {
         fun createFromVedtak(vedtak: Vedtak): VedtakResponseDTO =
@@ -31,6 +32,7 @@ data class VedtakResponseDTO private constructor(
                 veilederident = vedtak.getFattetStatus().veilederident,
                 ferdigbehandletAt = vedtak.getFerdigbehandletStatus()?.createdAt?.toLocalDateTime(),
                 ferdigbehandletBy = vedtak.getFerdigbehandletStatus()?.veilederident,
+                infotrygdStatus = vedtak.infotrygdStatus.name,
             )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/domain/InfotrygdStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/InfotrygdStatus.kt
@@ -1,0 +1,25 @@
+package no.nav.syfo.domain
+
+import java.time.OffsetDateTime
+
+enum class InfotrygdStatus {
+    IKKE_SENDT,
+    KVITTERING_MANGLER,
+    KVITTERING_OK,
+    KVITTERING_FEIL;
+
+    companion object {
+        fun create(publishedInfotrygdAt: OffsetDateTime?, infotrygdOk: Boolean?): InfotrygdStatus =
+            when (publishedInfotrygdAt) {
+                null -> {
+                    IKKE_SENDT
+                }
+
+                else -> when (infotrygdOk) {
+                    null -> KVITTERING_MANGLER
+                    true -> KVITTERING_OK
+                    false -> KVITTERING_FEIL
+                }
+            }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/domain/Vedtak.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vedtak.kt
@@ -15,6 +15,7 @@ data class Vedtak private constructor(
     val tom: LocalDate,
     val journalpostId: JournalpostId?,
     val statusListe: List<VedtakStatus>,
+    val infotrygdStatus: InfotrygdStatus,
 ) {
     constructor(
         personident: Personident,
@@ -38,6 +39,7 @@ data class Vedtak private constructor(
                 status = Status.FATTET,
             )
         ),
+        infotrygdStatus = InfotrygdStatus.IKKE_SENDT,
     )
 
     fun journalfor(journalpostId: JournalpostId): Vedtak = this.copy(journalpostId = journalpostId)
@@ -66,6 +68,7 @@ data class Vedtak private constructor(
             tom: LocalDate,
             journalpostId: JournalpostId?,
             vedtakStatus: List<VedtakStatus>,
+            infotrygdStatus: InfotrygdStatus,
         ) = Vedtak(
             uuid = uuid,
             personident = personident,
@@ -76,6 +79,7 @@ data class Vedtak private constructor(
             tom = tom,
             journalpostId = journalpostId,
             statusListe = vedtakStatus,
+            infotrygdStatus = infotrygdStatus,
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/Database.kt
@@ -58,3 +58,11 @@ fun <T> ResultSet.toList(mapper: ResultSet.() -> T) = mutableListOf<T>().apply {
         add(mapper())
     }
 }
+
+fun ResultSet.getNullableBoolean(columnLabel: String): Boolean? {
+    val boolean = this.getBoolean(columnLabel)
+    if (this.wasNull()) {
+        return null
+    }
+    return boolean
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVedtak.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVedtak.kt
@@ -1,9 +1,6 @@
 package no.nav.syfo.infrastructure.database.repository
 
-import no.nav.syfo.domain.DocumentComponent
-import no.nav.syfo.domain.JournalpostId
-import no.nav.syfo.domain.Personident
-import no.nav.syfo.domain.Vedtak
+import no.nav.syfo.domain.*
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -22,6 +19,7 @@ data class PVedtak(
     val pdfId: Int,
     val publishedInfotrygdAt: OffsetDateTime?,
     val varselPublishedAt: OffsetDateTime?,
+    val infotrygdOk: Boolean?,
 ) {
     fun toVedtak(statusListe: List<PVedtakStatus>): Vedtak = Vedtak.createFromDatabase(
         uuid = uuid,
@@ -35,5 +33,6 @@ data class PVedtak(
         vedtakStatus = statusListe.map {
             it.toVedtakStatus()
         },
+        infotrygdStatus = InfotrygdStatus.create(publishedInfotrygdAt, infotrygdOk),
     )
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VedtakRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VedtakRepository.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import no.nav.syfo.application.IVedtakRepository
 import no.nav.syfo.domain.*
 import no.nav.syfo.infrastructure.database.DatabaseInterface
+import no.nav.syfo.infrastructure.database.getNullableBoolean
 import no.nav.syfo.infrastructure.database.toList
 import no.nav.syfo.util.configuredJacksonMapper
 import no.nav.syfo.util.nowUTC
@@ -381,6 +382,7 @@ internal fun ResultSet.toPVedtak(): PVedtak = PVedtak(
     pdfId = getInt("pdf_id"),
     publishedInfotrygdAt = getObject("published_infotrygd_at", OffsetDateTime::class.java),
     varselPublishedAt = getObject("varsel_published_at", OffsetDateTime::class.java),
+    infotrygdOk = getNullableBoolean("infotrygd_ok"),
 )
 
 internal fun ResultSet.toPVedtakStatus(): PVedtakStatus = PVedtakStatus(

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.api.model.VedtakRequestDTO
 import no.nav.syfo.api.model.VedtakResponseDTO
 import no.nav.syfo.application.IVedtakProducer
 import no.nav.syfo.application.VedtakService
+import no.nav.syfo.domain.InfotrygdStatus
 import no.nav.syfo.generator.generateDocumentComponent
 import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.infrastructure.bearerHeader
@@ -132,6 +133,7 @@ object VedtakEndpointsSpek : Spek({
                             vedtakResponse[0].tom shouldBeEqualTo vedtakTom
                             vedtakResponse[0].personident shouldBeEqualTo personident.value
                             vedtakResponse[0].veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                            vedtakResponse[0].infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT.name
 
                             val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse[0].uuid)?.pdf!!
                             vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjobSpek.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
 import no.nav.syfo.application.IVedtakProducer
 import no.nav.syfo.application.VedtakService
+import no.nav.syfo.domain.InfotrygdStatus
 import no.nav.syfo.generator.generateDocumentComponent
 import no.nav.syfo.infrastructure.database.dropData
 import no.nav.syfo.infrastructure.database.getPublishedInfotrygdAt
@@ -16,6 +17,7 @@ import no.nav.syfo.infrastructure.journalforing.JournalforingService
 import no.nav.syfo.infrastructure.mq.InfotrygdMQSender
 import no.nav.syfo.infrastructure.pdf.PdfService
 import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBe
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -60,6 +62,8 @@ class PublishMQCronjobSpek : Spek({
                             callId = "callId",
                         )
                     }
+
+                    vedtak.infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT
                     database.getPublishedInfotrygdAt(vedtak.uuid) shouldBe null
 
                     runBlocking {
@@ -77,6 +81,9 @@ class PublishMQCronjobSpek : Spek({
                         publishMQCronjob.run()
                     }
                     verify(exactly = 0) { mqSenderMock.sendToMQ(any(), any()) }
+
+                    val publishedVedtak = vedtakService.getVedtak(personident = UserConstants.ARBEIDSTAKER_PERSONIDENT).first()
+                    publishedVedtak.infotrygdStatus shouldBeEqualTo InfotrygdStatus.KVITTERING_MANGLER
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
@@ -94,18 +94,6 @@ fun TestDatabase.getVedtakVarselPublishedAt(
         }
     }
 
-fun TestDatabase.getVedtakInfotrygdKvittering(
-    vedtakUuid: UUID,
-): Boolean? =
-    this.connection.use { connection ->
-        connection.prepareStatement(queryGetVedtakInfotrygdKvittering).use {
-            it.setString(1, vedtakUuid.toString())
-            it.executeQuery()
-                .toList { getBoolean("infotrygd_ok") }
-                .singleOrNull()
-        }
-    }
-
 fun TestDatabase.getVedtakInfotrygdFeilmelding(
     vedtakUuid: UUID,
 ): String? =

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VedtakRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VedtakRepositorySpek.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.infrastructure.database
 import io.ktor.server.testing.*
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
+import no.nav.syfo.domain.InfotrygdStatus
 import no.nav.syfo.generator.generateVedtak
 import no.nav.syfo.infrastructure.database.repository.VedtakRepository
 import org.amshove.kluent.shouldBe
@@ -43,6 +44,7 @@ class VedtakRepositorySpek : Spek({
                 vedtak.fom shouldBeEqualTo persistedVedtak.fom
                 vedtak.tom shouldBeEqualTo persistedVedtak.tom
                 vedtak.journalpostId shouldBeEqualTo persistedVedtak.journalpostId
+                vedtak.infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT
             }
         }
     }


### PR DESCRIPTION
Legger til rette for å vise informasjon til veileder om sending til infotrygd feilet. 

Laget en enum for statusen i stedet for å ha db-feltene (`publishedInfotrygdAt` og `infotrygdOk`) i `Vedtak` og `VedtakResponseDTO`. Tenkte det blir lettere for frontend å forholde seg til :man_shrugging: 