### PR TITLE
IS-2660: Send to infotrygd api

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
@@ -53,15 +53,19 @@ class VedtakService(
         }
     }
 
-    suspend fun sendVedtakToInfotrygd(): List<Result<Vedtak>> {
+    suspend fun sendUnpublishedVedtakToInfotrygd(): List<Result<Vedtak>> {
         val unpublished = vedtakRepository.getUnpublishedInfotrygd()
         return unpublished.map { vedtak ->
             runCatching {
-                infotrygdService.sendMessageToInfotrygd(vedtak)
-                vedtakRepository.setVedtakPublishedInfotrygd(vedtak)
-                vedtak
+                sendVedtakToInfotrygd(vedtak)
             }
         }
+    }
+
+    internal suspend fun sendVedtakToInfotrygd(vedtak: Vedtak): Vedtak {
+        infotrygdService.sendMessageToInfotrygd(vedtak)
+        vedtakRepository.setVedtakPublishedInfotrygd(vedtak)
+        return vedtak.sendTilInfotrygd()
     }
 
     suspend fun journalforVedtak(): List<Result<Vedtak>> {

--- a/src/main/kotlin/no/nav/syfo/domain/Vedtak.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vedtak.kt
@@ -44,6 +44,8 @@ data class Vedtak private constructor(
 
     fun journalfor(journalpostId: JournalpostId): Vedtak = this.copy(journalpostId = journalpostId)
 
+    fun sendTilInfotrygd(): Vedtak = this.copy(infotrygdStatus = InfotrygdStatus.KVITTERING_MANGLER)
+
     fun addVedtakstatus(vedtakStatus: VedtakStatus): Vedtak = this.copy(
         statusListe = this.statusListe.toMutableList().also {
             it.add(vedtakStatus)
@@ -51,6 +53,8 @@ data class Vedtak private constructor(
     )
 
     fun isFerdigbehandlet(): Boolean = statusListe.any { it.status == Status.FERDIG_BEHANDLET }
+
+    fun isSendtTilInfotrygd(): Boolean = infotrygdStatus !== InfotrygdStatus.IKKE_SENDT
 
     fun getFattetStatus(): VedtakStatus = statusListe.first { it.status == Status.FATTET }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjob.kt
@@ -8,5 +8,5 @@ class PublishMQCronjob(
     override val initialDelayMinutes: Long = 2
     override val intervalDelayMinutes: Long = 1
 
-    override suspend fun run() = vedtakService.sendVedtakToInfotrygd()
+    override suspend fun run() = vedtakService.sendUnpublishedVedtakToInfotrygd()
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VedtakRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VedtakRepository.kt
@@ -283,7 +283,7 @@ class VedtakRepository(private val database: DatabaseInterface) : IVedtakReposit
 
         private const val GET_UNPUBLISHED_INFOTRYGD =
             """
-                SELECT * FROM VEDTAK WHERE published_infotrygd_at IS NULL
+                SELECT * FROM VEDTAK WHERE published_infotrygd_at IS NULL AND created_at < now() - interval '10 minutes'
             """
 
         private const val SET_PUBLISHED_INFOTRYGD =

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.infrastructure.pdf.PdfService
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment,
+    infotrygdMQSender: InfotrygdMQSender,
 ) {
     val database = externalMockEnvironment.database
     val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
@@ -36,7 +37,7 @@ fun Application.testApiModule(
         journalforingService = journalforingService,
         infotrygdService = InfotrygdService(
             pdlClient = externalMockEnvironment.pdlClient,
-            mqSender = mockk<InfotrygdMQSender>(relaxed = true),
+            mqSender = infotrygdMQSender,
         ),
         vedtakProducer = mockk<IVedtakProducer>(relaxed = true),
     )

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
 import io.ktor.server.testing.*
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.ExternalMockEnvironment
@@ -23,6 +26,7 @@ import no.nav.syfo.infrastructure.database.getVedtakPdf
 import no.nav.syfo.infrastructure.database.repository.VedtakRepository
 import no.nav.syfo.infrastructure.infotrygd.InfotrygdService
 import no.nav.syfo.infrastructure.journalforing.JournalforingService
+import no.nav.syfo.infrastructure.mq.InfotrygdMQSender
 import no.nav.syfo.infrastructure.pdf.PdfService
 import no.nav.syfo.util.configuredJacksonMapper
 import org.amshove.kluent.*
@@ -76,8 +80,10 @@ object VedtakEndpointsSpek : Spek({
                 infotrygdService = mockk<InfotrygdService>(relaxed = true),
                 vedtakProducer = mockk<IVedtakProducer>(relaxed = true),
             )
+            val infotrygdMQSender = mockk<InfotrygdMQSender>(relaxed = true)
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
+                infotrygdMQSender = infotrygdMQSender,
             )
 
             fun createVedtak(
@@ -95,210 +101,273 @@ object VedtakEndpointsSpek : Spek({
             }
 
             beforeEachTest {
+                clearAllMocks()
+                justRun { infotrygdMQSender.sendToMQ(any(), any()) }
                 database.dropData()
             }
 
-            describe("POST vedtak") {
-                describe("Happy path") {
-                    it("Successfully gets empty list of vedtak") {
-                        with(
-                            handleRequest(HttpMethod.Get, urlVedtak) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-
-                            val responseDTOs = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
-                            responseDTOs.size shouldBeEqualTo 0
+            describe("GET vedtak") {
+                it("Successfully gets empty list of vedtak") {
+                    with(
+                        handleRequest(HttpMethod.Get, urlVedtak) {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
                         }
-                    }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
 
-                    it("Successfully gets list of single vedtak") {
-                        createVedtak(vedtakRequestDTO)
-                        with(
-                            handleRequest(HttpMethod.Get, urlVedtak) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-
-                            val vedtakResponse = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
-                            vedtakResponse.size shouldBeEqualTo 1
-
-                            vedtakResponse[0].begrunnelse shouldBeEqualTo begrunnelse
-                            vedtakResponse[0].document shouldBeEqualTo vedtakDocument
-                            vedtakResponse[0].fom shouldBeEqualTo vedtakFom
-                            vedtakResponse[0].tom shouldBeEqualTo vedtakTom
-                            vedtakResponse[0].personident shouldBeEqualTo personident.value
-                            vedtakResponse[0].veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
-                            vedtakResponse[0].infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT.name
-
-                            val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse[0].uuid)?.pdf!!
-                            vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size
-                            vedtakPdf[0] shouldBeEqualTo PDF_VEDTAK[0]
-                            vedtakPdf[1] shouldBeEqualTo PDF_VEDTAK[1]
-
-                            val vedtak = vedtakRepository.getVedtak(vedtakResponse[0].uuid)
-                            vedtak.uuid shouldBeEqualTo vedtakResponse[0].uuid
-                        }
-                    }
-                    it("Successfully gets list of multiple vedtak") {
-                        createVedtak(
-                            vedtakRequestDTO.copy(
-                                fom = vedtakRequestDTO.fom.minusYears(1),
-                                tom = vedtakRequestDTO.tom.minusYears(1),
-                            )
-                        )
-                        createVedtak(vedtakRequestDTO)
-
-                        with(
-                            handleRequest(HttpMethod.Get, urlVedtak) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-
-                            val vedtakResponse = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
-                            vedtakResponse.size shouldBeEqualTo 2
-                            vedtakResponse[0].createdAt shouldBeAfter vedtakResponse[1].createdAt
-                        }
-                    }
-
-                    it("Creates vedtak") {
-                        with(
-                            handleRequest(HttpMethod.Post, urlVedtak) {
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                                setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.Created
-
-                            val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
-
-                            vedtakResponse.begrunnelse shouldBeEqualTo begrunnelse
-                            vedtakResponse.document shouldBeEqualTo vedtakDocument
-                            vedtakResponse.fom shouldBeEqualTo vedtakFom
-                            vedtakResponse.tom shouldBeEqualTo vedtakTom
-                            vedtakResponse.personident shouldBeEqualTo personident.value
-                            vedtakResponse.veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
-
-                            val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse.uuid)?.pdf!!
-                            vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size
-                            vedtakPdf[0] shouldBeEqualTo PDF_VEDTAK[0]
-                            vedtakPdf[1] shouldBeEqualTo PDF_VEDTAK[1]
-
-                            val vedtak = vedtakRepository.getVedtak(vedtakResponse.uuid)
-                            vedtak.uuid shouldBeEqualTo vedtakResponse.uuid
-                        }
-                    }
-                    it("Sets vedtak ferdigbehandlet and updates veileder") {
-                        val vedtak = createVedtak(vedtakRequestDTO)
-                        with(
-                            handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/ferdigbehandling") {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validTokenOther))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-                            val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
-                            vedtakResponse.uuid shouldBeEqualTo vedtak.uuid
-                            vedtakResponse.ferdigbehandletAt shouldNotBe null
-                            vedtakResponse.ferdigbehandletBy shouldBeEqualTo UserConstants.VEILEDER_IDENT_OTHER
-
-                            val vedtakPersisted = vedtakRepository.getVedtak(vedtak.uuid)
-
-                            vedtakPersisted.isFerdigbehandlet() shouldBe true
-                            vedtakPersisted.getFerdigbehandletStatus()!!.veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT_OTHER
-                        }
+                        val responseDTOs = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
+                        responseDTOs.size shouldBeEqualTo 0
                     }
                 }
 
-                describe("Unhappy path") {
-                    it("Throws error when document is empty") {
-                        val vedtakWithoutDocument = vedtakRequestDTO.copy(document = emptyList())
-                        with(
-                            handleRequest(HttpMethod.Post, urlVedtak) {
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                                setBody(objectMapper.writeValueAsString(vedtakWithoutDocument))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                it("Successfully gets list of single vedtak") {
+                    createVedtak(vedtakRequestDTO)
+                    with(
+                        handleRequest(HttpMethod.Get, urlVedtak) {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
                         }
-                    }
-                    it("Throws error when begrunnelse is empty") {
-                        val vedtakWithoutBegrunnelse = vedtakRequestDTO.copy(begrunnelse = "")
-                        with(
-                            handleRequest(HttpMethod.Post, urlVedtak) {
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                                setBody(objectMapper.writeValueAsString(vedtakWithoutBegrunnelse))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
-                        }
-                    }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
 
-                    it("Returns status Conflict when vedtak not ferdigbehandlet exists") {
-                        createVedtak(vedtakRequestDTO)
+                        val vedtakResponse = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
+                        vedtakResponse.size shouldBeEqualTo 1
 
-                        with(
-                            handleRequest(HttpMethod.Post, urlVedtak) {
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                                setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.Conflict
-                        }
-                    }
+                        vedtakResponse[0].begrunnelse shouldBeEqualTo begrunnelse
+                        vedtakResponse[0].document shouldBeEqualTo vedtakDocument
+                        vedtakResponse[0].fom shouldBeEqualTo vedtakFom
+                        vedtakResponse[0].tom shouldBeEqualTo vedtakTom
+                        vedtakResponse[0].personident shouldBeEqualTo personident.value
+                        vedtakResponse[0].veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                        vedtakResponse[0].infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT.name
 
-                    it("Throws error when ferdigstiller unknown vedtak") {
-                        with(
-                            handleRequest(HttpMethod.Put, "$urlVedtak/${UUID.randomUUID()}/ferdigbehandling") {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse[0].uuid)?.pdf!!
+                        vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size
+                        vedtakPdf[0] shouldBeEqualTo PDF_VEDTAK[0]
+                        vedtakPdf[1] shouldBeEqualTo PDF_VEDTAK[1]
+
+                        val vedtak = vedtakRepository.getVedtak(vedtakResponse[0].uuid)
+                        vedtak.uuid shouldBeEqualTo vedtakResponse[0].uuid
+                    }
+                }
+                it("Successfully gets list of multiple vedtak") {
+                    createVedtak(
+                        vedtakRequestDTO.copy(
+                            fom = vedtakRequestDTO.fom.minusYears(1),
+                            tom = vedtakRequestDTO.tom.minusYears(1),
+                        )
+                    )
+                    createVedtak(vedtakRequestDTO)
+
+                    with(
+                        handleRequest(HttpMethod.Get, urlVedtak) {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
                         }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        val vedtakResponse = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
+                        vedtakResponse.size shouldBeEqualTo 2
+                        vedtakResponse[0].createdAt shouldBeAfter vedtakResponse[1].createdAt
                     }
-                    it("Throws error when ferdigbehandler already ferdigbehandlet vedtak") {
-                        val vedtak = createVedtak(vedtakRequestDTO)
-                        vedtakService.ferdigbehandleVedtak(vedtak, UserConstants.VEILEDER_IDENT)
-                        with(
-                            handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/ferdigbehandling") {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                }
+            }
+
+            describe("POST vedtak") {
+                it("Creates vedtak") {
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
                         }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Created
+
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+
+                        vedtakResponse.begrunnelse shouldBeEqualTo begrunnelse
+                        vedtakResponse.document shouldBeEqualTo vedtakDocument
+                        vedtakResponse.fom shouldBeEqualTo vedtakFom
+                        vedtakResponse.tom shouldBeEqualTo vedtakTom
+                        vedtakResponse.personident shouldBeEqualTo personident.value
+                        vedtakResponse.veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+
+                        val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse.uuid)?.pdf!!
+                        vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size
+                        vedtakPdf[0] shouldBeEqualTo PDF_VEDTAK[0]
+                        vedtakPdf[1] shouldBeEqualTo PDF_VEDTAK[1]
+
+                        val vedtak = vedtakRepository.getVedtak(vedtakResponse.uuid)
+                        vedtak.uuid shouldBeEqualTo vedtakResponse.uuid
                     }
-                    it("Returns status Unauthorized if no token is supplied") {
-                        testMissingToken(urlVedtak, HttpMethod.Get)
-                        testMissingToken(urlVedtak, HttpMethod.Post)
+                }
+                it("Throws error when document is empty") {
+                    val vedtakWithoutDocument = vedtakRequestDTO.copy(document = emptyList())
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakWithoutDocument))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
                     }
-                    it("Returns status Forbidden if denied access to person") {
-                        testDeniedPersonAccess(urlVedtak, validToken, HttpMethod.Get)
-                        testDeniedPersonAccess(urlVedtak, validToken, HttpMethod.Post)
+                }
+                it("Throws error when begrunnelse is empty") {
+                    val vedtakWithoutBegrunnelse = vedtakRequestDTO.copy(begrunnelse = "")
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakWithoutBegrunnelse))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
                     }
-                    it("Returns status BadRequest if no $NAV_PERSONIDENT_HEADER is supplied") {
-                        testMissingPersonIdent(urlVedtak, validToken, HttpMethod.Get)
-                        testMissingPersonIdent(urlVedtak, validToken, HttpMethod.Post)
+                }
+                it("Returns status Conflict when vedtak not ferdigbehandlet exists") {
+                    createVedtak(vedtakRequestDTO)
+
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Conflict
                     }
-                    it("Returns status BadRequest if $NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied") {
-                        testInvalidPersonIdent(urlVedtak, validToken, HttpMethod.Get)
-                        testInvalidPersonIdent(urlVedtak, validToken, HttpMethod.Post)
+                }
+            }
+
+            describe("PUT vedtak ferdigbehandlet") {
+                it("Sets vedtak ferdigbehandlet and updates veileder") {
+                    val vedtak = createVedtak(vedtakRequestDTO)
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/ferdigbehandling") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validTokenOther))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+                        vedtakResponse.uuid shouldBeEqualTo vedtak.uuid
+                        vedtakResponse.ferdigbehandletAt shouldNotBe null
+                        vedtakResponse.ferdigbehandletBy shouldBeEqualTo UserConstants.VEILEDER_IDENT_OTHER
+
+                        val vedtakPersisted = vedtakRepository.getVedtak(vedtak.uuid)
+
+                        vedtakPersisted.isFerdigbehandlet() shouldBe true
+                        vedtakPersisted.getFerdigbehandletStatus()!!.veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT_OTHER
                     }
+                }
+                it("Throws error when ferdigstiller unknown vedtak") {
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${UUID.randomUUID()}/ferdigbehandling") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+                it("Throws error when ferdigbehandler already ferdigbehandlet vedtak") {
+                    val vedtak = createVedtak(vedtakRequestDTO)
+                    vedtakService.ferdigbehandleVedtak(vedtak, UserConstants.VEILEDER_IDENT)
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/ferdigbehandling") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+            }
+
+            describe("PUT send infotrygd") {
+                it("Sends vedtak to infotrygd and updates infotrygd-status") {
+                    val vedtak = createVedtak(vedtakRequestDTO)
+
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/send-infotrygd") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validTokenOther))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+                        vedtakResponse.uuid shouldBeEqualTo vedtak.uuid
+                        vedtakResponse.infotrygdStatus shouldBeEqualTo InfotrygdStatus.KVITTERING_MANGLER.name
+
+                        val vedtakPersisted = vedtakRepository.getVedtak(vedtak.uuid)
+
+                        vedtakPersisted.isSendtTilInfotrygd() shouldBeEqualTo true
+                        vedtakPersisted.infotrygdStatus shouldBeEqualTo InfotrygdStatus.KVITTERING_MANGLER
+                    }
+                }
+                it("Throws error when unknown vedtak") {
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${UUID.randomUUID()}/send-infotrygd") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validTokenOther))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+                it("Throws error when vedtak already sent to infotrygd") {
+                    val vedtak = createVedtak(vedtakRequestDTO)
+                    runBlocking { vedtakService.sendVedtakToInfotrygd(vedtak) }
+
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/send-infotrygd") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validTokenOther))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+                it("Throws error when sending message to infotrygd fails") {
+                    val vedtak = createVedtak(vedtakRequestDTO)
+                    every { infotrygdMQSender.sendToMQ(any(), any()) } throws Exception("Error sending to infotrygd")
+
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/send-infotrygd") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validTokenOther))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.InternalServerError
+                    }
+                }
+            }
+
+            describe("Unhappy paths") {
+                it("Returns status Unauthorized if no token is supplied") {
+                    testMissingToken(urlVedtak, HttpMethod.Get)
+                    testMissingToken(urlVedtak, HttpMethod.Post)
+                }
+                it("Returns status Forbidden if denied access to person") {
+                    testDeniedPersonAccess(urlVedtak, validToken, HttpMethod.Get)
+                    testDeniedPersonAccess(urlVedtak, validToken, HttpMethod.Post)
+                }
+                it("Returns status BadRequest if no $NAV_PERSONIDENT_HEADER is supplied") {
+                    testMissingPersonIdent(urlVedtak, validToken, HttpMethod.Get)
+                    testMissingPersonIdent(urlVedtak, validToken, HttpMethod.Post)
+                }
+                it("Returns status BadRequest if $NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied") {
+                    testInvalidPersonIdent(urlVedtak, validToken, HttpMethod.Get)
+                    testInvalidPersonIdent(urlVedtak, validToken, HttpMethod.Post)
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
@@ -118,6 +118,23 @@ fun TestDatabase.getVedtakStatusPublishedAt(
         }
     }
 
+fun TestDatabase.setVedtakCreatedAt(createdAt: OffsetDateTime, uuid: UUID) {
+    this.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            UPDATE vedtak
+            SET created_at = ?
+            WHERE uuid = ?
+            """
+        ).use {
+            it.setObject(1, createdAt)
+            it.setString(2, uuid.toString())
+            it.execute()
+        }
+        connection.commit()
+    }
+}
+
 private const val queryGetVedtak =
     """
         SELECT * FROM vedtak WHERE uuid = ?

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VedtakRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VedtakRepositorySpek.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.infrastructure.database
 import io.ktor.server.testing.*
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
-import no.nav.syfo.domain.InfotrygdStatus
 import no.nav.syfo.generator.generateVedtak
 import no.nav.syfo.infrastructure.database.repository.VedtakRepository
 import org.amshove.kluent.shouldBe
@@ -44,7 +43,7 @@ class VedtakRepositorySpek : Spek({
                 vedtak.fom shouldBeEqualTo persistedVedtak.fom
                 vedtak.tom shouldBeEqualTo persistedVedtak.tom
                 vedtak.journalpostId shouldBeEqualTo persistedVedtak.journalpostId
-                vedtak.infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT
+                vedtak.isSendtTilInfotrygd() shouldBeEqualTo false
             }
         }
     }


### PR DESCRIPTION
Nytt endepunkt for å sende vedtak til infotrygd som kan kalles fra frontend etter vedtak er fattet.

Tanken er å kalle endepunktet automatisk fra frontend når vedtak er fattet.
Deretter må frontend hente vedtak på nytt fra backend for å sjekke status på kvitteringen fra infotrygd (siden kvitterings-konsumeringen fra infotrygd skjer i egen bakgrunnsjobb i appen her og ikke synkront med sendingen), og så vise noe om det feilet.

Diskuterte et alternativ med @geir-waagboe om å la dette api-kallet "vente" x millisekunder og så sjekke i databasen om kvittering er mottatt (ser ut som vi får kvittering innen 1 sek) og gi respons, men det virker litt hårete, så tenkte forsøke å løse det i frontend først.

