### PR TITLE
IS-2660: Send vedtak to infotrygd in create vedtak api

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VedtakService.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.application
 import no.nav.syfo.domain.*
 import no.nav.syfo.infrastructure.infotrygd.InfotrygdService
 import java.time.LocalDate
+import java.util.*
 
 class VedtakService(
     private val pdfService: IPdfService,
@@ -13,6 +14,8 @@ class VedtakService(
 ) {
     fun getVedtak(personident: Personident) =
         vedtakRepository.getVedtak(personident)
+
+    fun getVedtak(uuid: UUID): Vedtak = vedtakRepository.getVedtak(uuid = uuid)
 
     suspend fun createVedtak(
         personident: Personident,
@@ -53,15 +56,17 @@ class VedtakService(
         }
     }
 
-    suspend fun sendVedtakToInfotrygd(): List<Result<Vedtak>> {
+    suspend fun sendUnpublishedVedtakToInfotrygd(): List<Result<Vedtak>> {
         val unpublished = vedtakRepository.getUnpublishedInfotrygd()
         return unpublished.map { vedtak ->
-            runCatching {
-                infotrygdService.sendMessageToInfotrygd(vedtak)
-                vedtakRepository.setVedtakPublishedInfotrygd(vedtak)
-                vedtak
-            }
+            sendVedtakToInfotrygd(vedtak)
         }
+    }
+
+    internal suspend fun sendVedtakToInfotrygd(vedtak: Vedtak): Result<Vedtak> = runCatching {
+        infotrygdService.sendMessageToInfotrygd(vedtak)
+        vedtakRepository.setVedtakPublishedInfotrygd(vedtak)
+        vedtak
     }
 
     suspend fun journalforVedtak(): List<Result<Vedtak>> {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjob.kt
@@ -8,5 +8,5 @@ class PublishMQCronjob(
     override val initialDelayMinutes: Long = 2
     override val intervalDelayMinutes: Long = 1
 
-    override suspend fun run() = vedtakService.sendVedtakToInfotrygd()
+    override suspend fun run() = vedtakService.sendUnpublishedVedtakToInfotrygd()
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VedtakRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VedtakRepository.kt
@@ -283,7 +283,7 @@ class VedtakRepository(private val database: DatabaseInterface) : IVedtakReposit
 
         private const val GET_UNPUBLISHED_INFOTRYGD =
             """
-                SELECT * FROM VEDTAK WHERE published_infotrygd_at IS NULL
+                SELECT * FROM VEDTAK WHERE published_infotrygd_at IS NULL AND created_at < now() - interval '1 minutes'
             """
 
         private const val SET_PUBLISHED_INFOTRYGD =

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.infrastructure.pdf.PdfService
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment,
+    infotrygdMQSender: InfotrygdMQSender,
 ) {
     val database = externalMockEnvironment.database
     val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
@@ -36,7 +37,7 @@ fun Application.testApiModule(
         journalforingService = journalforingService,
         infotrygdService = InfotrygdService(
             pdlClient = externalMockEnvironment.pdlClient,
-            mqSender = mockk<InfotrygdMQSender>(relaxed = true),
+            mqSender = infotrygdMQSender,
         ),
         vedtakProducer = mockk<IVedtakProducer>(relaxed = true),
     )

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
@@ -3,9 +3,10 @@ package no.nav.syfo.api.endpoints
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
+import io.ktor.server.application.*
 import io.ktor.server.testing.*
-import io.mockk.mockk
-import kotlinx.coroutines.runBlocking
+import io.mockk.*
+import kotlinx.coroutines.*
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
 import no.nav.syfo.UserConstants.PDF_VEDTAK
@@ -23,7 +24,9 @@ import no.nav.syfo.infrastructure.database.getVedtakPdf
 import no.nav.syfo.infrastructure.database.repository.VedtakRepository
 import no.nav.syfo.infrastructure.infotrygd.InfotrygdService
 import no.nav.syfo.infrastructure.journalforing.JournalforingService
+import no.nav.syfo.infrastructure.mq.InfotrygdMQSender
 import no.nav.syfo.infrastructure.pdf.PdfService
+import no.nav.syfo.testAppState
 import no.nav.syfo.util.configuredJacksonMapper
 import org.amshove.kluent.*
 import org.spekframework.spek2.Spek
@@ -76,8 +79,10 @@ object VedtakEndpointsSpek : Spek({
                 infotrygdService = mockk<InfotrygdService>(relaxed = true),
                 vedtakProducer = mockk<IVedtakProducer>(relaxed = true),
             )
+            val infotrygdMQSender = mockk<InfotrygdMQSender>(relaxed = true)
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
+                infotrygdMQSender = infotrygdMQSender,
             )
 
             fun createVedtak(
@@ -94,211 +99,320 @@ object VedtakEndpointsSpek : Spek({
                 )
             }
 
+            @OptIn(DelicateCoroutinesApi::class)
+            fun mockInfotrygdKvitteringReceived(kvitteringOk: Boolean) {
+                GlobalScope.launch {
+                    try {
+                        withTimeout(1000) {
+                            while (testAppState().ready) {
+                                val vedtak =
+                                    vedtakRepository.getVedtak(personident = UserConstants.ARBEIDSTAKER_PERSONIDENT)
+                                        .firstOrNull()
+                                if (vedtak != null) {
+                                    vedtakRepository.setInfotrygdKvitteringReceived(
+                                        vedtak = vedtak,
+                                        ok = kvitteringOk,
+                                        feilmelding = null,
+                                    )
+                                    break
+                                } else {
+                                    delay(100)
+                                }
+                            }
+                        }
+                    } catch (e: TimeoutCancellationException) {
+                        application.log.error("Timeout waiting for vedtak to receive kvittering")
+                    }
+                }
+            }
+
             beforeEachTest {
+                clearAllMocks()
+                justRun { infotrygdMQSender.sendToMQ(any(), any()) }
                 database.dropData()
             }
 
-            describe("POST vedtak") {
-                describe("Happy path") {
-                    it("Successfully gets empty list of vedtak") {
-                        with(
-                            handleRequest(HttpMethod.Get, urlVedtak) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-
-                            val responseDTOs = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
-                            responseDTOs.size shouldBeEqualTo 0
+            describe("GET vedtak") {
+                it("Successfully gets empty list of vedtak") {
+                    with(
+                        handleRequest(HttpMethod.Get, urlVedtak) {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
                         }
-                    }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
 
-                    it("Successfully gets list of single vedtak") {
-                        createVedtak(vedtakRequestDTO)
-                        with(
-                            handleRequest(HttpMethod.Get, urlVedtak) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-
-                            val vedtakResponse = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
-                            vedtakResponse.size shouldBeEqualTo 1
-
-                            vedtakResponse[0].begrunnelse shouldBeEqualTo begrunnelse
-                            vedtakResponse[0].document shouldBeEqualTo vedtakDocument
-                            vedtakResponse[0].fom shouldBeEqualTo vedtakFom
-                            vedtakResponse[0].tom shouldBeEqualTo vedtakTom
-                            vedtakResponse[0].personident shouldBeEqualTo personident.value
-                            vedtakResponse[0].veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
-                            vedtakResponse[0].infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT.name
-
-                            val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse[0].uuid)?.pdf!!
-                            vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size
-                            vedtakPdf[0] shouldBeEqualTo PDF_VEDTAK[0]
-                            vedtakPdf[1] shouldBeEqualTo PDF_VEDTAK[1]
-
-                            val vedtak = vedtakRepository.getVedtak(vedtakResponse[0].uuid)
-                            vedtak.uuid shouldBeEqualTo vedtakResponse[0].uuid
-                        }
-                    }
-                    it("Successfully gets list of multiple vedtak") {
-                        createVedtak(
-                            vedtakRequestDTO.copy(
-                                fom = vedtakRequestDTO.fom.minusYears(1),
-                                tom = vedtakRequestDTO.tom.minusYears(1),
-                            )
-                        )
-                        createVedtak(vedtakRequestDTO)
-
-                        with(
-                            handleRequest(HttpMethod.Get, urlVedtak) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-
-                            val vedtakResponse = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
-                            vedtakResponse.size shouldBeEqualTo 2
-                            vedtakResponse[0].createdAt shouldBeAfter vedtakResponse[1].createdAt
-                        }
-                    }
-
-                    it("Creates vedtak") {
-                        with(
-                            handleRequest(HttpMethod.Post, urlVedtak) {
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                                setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.Created
-
-                            val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
-
-                            vedtakResponse.begrunnelse shouldBeEqualTo begrunnelse
-                            vedtakResponse.document shouldBeEqualTo vedtakDocument
-                            vedtakResponse.fom shouldBeEqualTo vedtakFom
-                            vedtakResponse.tom shouldBeEqualTo vedtakTom
-                            vedtakResponse.personident shouldBeEqualTo personident.value
-                            vedtakResponse.veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
-
-                            val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse.uuid)?.pdf!!
-                            vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size
-                            vedtakPdf[0] shouldBeEqualTo PDF_VEDTAK[0]
-                            vedtakPdf[1] shouldBeEqualTo PDF_VEDTAK[1]
-
-                            val vedtak = vedtakRepository.getVedtak(vedtakResponse.uuid)
-                            vedtak.uuid shouldBeEqualTo vedtakResponse.uuid
-                        }
-                    }
-                    it("Sets vedtak ferdigbehandlet and updates veileder") {
-                        val vedtak = createVedtak(vedtakRequestDTO)
-                        with(
-                            handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/ferdigbehandling") {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validTokenOther))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-                            val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
-                            vedtakResponse.uuid shouldBeEqualTo vedtak.uuid
-                            vedtakResponse.ferdigbehandletAt shouldNotBe null
-                            vedtakResponse.ferdigbehandletBy shouldBeEqualTo UserConstants.VEILEDER_IDENT_OTHER
-
-                            val vedtakPersisted = vedtakRepository.getVedtak(vedtak.uuid)
-
-                            vedtakPersisted.isFerdigbehandlet() shouldBe true
-                            vedtakPersisted.getFerdigbehandletStatus()!!.veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT_OTHER
-                        }
+                        val responseDTOs = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
+                        responseDTOs.size shouldBeEqualTo 0
                     }
                 }
 
-                describe("Unhappy path") {
-                    it("Throws error when document is empty") {
-                        val vedtakWithoutDocument = vedtakRequestDTO.copy(document = emptyList())
-                        with(
-                            handleRequest(HttpMethod.Post, urlVedtak) {
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                                setBody(objectMapper.writeValueAsString(vedtakWithoutDocument))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                it("Successfully gets list of single vedtak") {
+                    createVedtak(vedtakRequestDTO)
+                    with(
+                        handleRequest(HttpMethod.Get, urlVedtak) {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
                         }
-                    }
-                    it("Throws error when begrunnelse is empty") {
-                        val vedtakWithoutBegrunnelse = vedtakRequestDTO.copy(begrunnelse = "")
-                        with(
-                            handleRequest(HttpMethod.Post, urlVedtak) {
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                                setBody(objectMapper.writeValueAsString(vedtakWithoutBegrunnelse))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
-                        }
-                    }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
 
-                    it("Returns status Conflict when vedtak not ferdigbehandlet exists") {
-                        createVedtak(vedtakRequestDTO)
+                        val vedtakResponse = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
+                        vedtakResponse.size shouldBeEqualTo 1
 
-                        with(
-                            handleRequest(HttpMethod.Post, urlVedtak) {
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                                setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.Conflict
-                        }
-                    }
+                        vedtakResponse[0].begrunnelse shouldBeEqualTo begrunnelse
+                        vedtakResponse[0].document shouldBeEqualTo vedtakDocument
+                        vedtakResponse[0].fom shouldBeEqualTo vedtakFom
+                        vedtakResponse[0].tom shouldBeEqualTo vedtakTom
+                        vedtakResponse[0].personident shouldBeEqualTo personident.value
+                        vedtakResponse[0].veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                        vedtakResponse[0].infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT.name
 
-                    it("Throws error when ferdigstiller unknown vedtak") {
-                        with(
-                            handleRequest(HttpMethod.Put, "$urlVedtak/${UUID.randomUUID()}/ferdigbehandling") {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse[0].uuid)?.pdf!!
+                        vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size
+                        vedtakPdf[0] shouldBeEqualTo PDF_VEDTAK[0]
+                        vedtakPdf[1] shouldBeEqualTo PDF_VEDTAK[1]
+
+                        val vedtak = vedtakRepository.getVedtak(vedtakResponse[0].uuid)
+                        vedtak.uuid shouldBeEqualTo vedtakResponse[0].uuid
+                    }
+                }
+                it("Successfully gets list of multiple vedtak") {
+                    createVedtak(
+                        vedtakRequestDTO.copy(
+                            fom = vedtakRequestDTO.fom.minusYears(1),
+                            tom = vedtakRequestDTO.tom.minusYears(1),
+                        )
+                    )
+                    createVedtak(vedtakRequestDTO)
+
+                    with(
+                        handleRequest(HttpMethod.Get, urlVedtak) {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
                         }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        val vedtakResponse = objectMapper.readValue<List<VedtakResponseDTO>>(response.content!!)
+                        vedtakResponse.size shouldBeEqualTo 2
+                        vedtakResponse[0].createdAt shouldBeAfter vedtakResponse[1].createdAt
                     }
-                    it("Throws error when ferdigbehandler already ferdigbehandlet vedtak") {
-                        val vedtak = createVedtak(vedtakRequestDTO)
-                        vedtakService.ferdigbehandleVedtak(vedtak, UserConstants.VEILEDER_IDENT)
-                        with(
-                            handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/ferdigbehandling") {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
-                                addHeader(NAV_PERSONIDENT_HEADER, personident.value)
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                }
+            }
+
+            describe("POST vedtak") {
+                it("Creates vedtak") {
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
                         }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Created
+
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+
+                        vedtakResponse.begrunnelse shouldBeEqualTo begrunnelse
+                        vedtakResponse.document shouldBeEqualTo vedtakDocument
+                        vedtakResponse.fom shouldBeEqualTo vedtakFom
+                        vedtakResponse.tom shouldBeEqualTo vedtakTom
+                        vedtakResponse.personident shouldBeEqualTo personident.value
+                        vedtakResponse.veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+
+                        val vedtakPdf = database.getVedtakPdf(vedtakUuid = vedtakResponse.uuid)?.pdf!!
+                        vedtakPdf.size shouldBeEqualTo PDF_VEDTAK.size
+                        vedtakPdf[0] shouldBeEqualTo PDF_VEDTAK[0]
+                        vedtakPdf[1] shouldBeEqualTo PDF_VEDTAK[1]
+
+                        val vedtak = vedtakRepository.getVedtak(vedtakResponse.uuid)
+                        vedtak.uuid shouldBeEqualTo vedtakResponse.uuid
                     }
-                    it("Returns status Unauthorized if no token is supplied") {
-                        testMissingToken(urlVedtak, HttpMethod.Get)
-                        testMissingToken(urlVedtak, HttpMethod.Post)
+                }
+
+                it("Creates vedtak and publish to infotrygd success") {
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Created
+
+                        verify(exactly = 1) { infotrygdMQSender.sendToMQ(any(), any()) }
+
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+                        vedtakResponse.infotrygdStatus shouldBeEqualTo InfotrygdStatus.KVITTERING_MANGLER.name
                     }
-                    it("Returns status Forbidden if denied access to person") {
-                        testDeniedPersonAccess(urlVedtak, validToken, HttpMethod.Get)
-                        testDeniedPersonAccess(urlVedtak, validToken, HttpMethod.Post)
+                }
+
+                it("Creates vedtak and publish to infotrygd fails") {
+                    every { infotrygdMQSender.sendToMQ(any(), any()) } throws Exception("Error sending to infotrygd")
+
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Created
+
+                        verify(exactly = 1) { infotrygdMQSender.sendToMQ(any(), any()) }
+
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+                        vedtakResponse.infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT.name
                     }
-                    it("Returns status BadRequest if no $NAV_PERSONIDENT_HEADER is supplied") {
-                        testMissingPersonIdent(urlVedtak, validToken, HttpMethod.Get)
-                        testMissingPersonIdent(urlVedtak, validToken, HttpMethod.Post)
+                }
+
+                it("Creates vedtak and publish to infotrygd success with kvittering OK") {
+                    mockInfotrygdKvitteringReceived(kvitteringOk = true)
+
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Created
+
+                        verify(exactly = 1) { infotrygdMQSender.sendToMQ(any(), any()) }
+
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+                        vedtakResponse.infotrygdStatus shouldBeEqualTo InfotrygdStatus.KVITTERING_OK.name
                     }
-                    it("Returns status BadRequest if $NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied") {
-                        testInvalidPersonIdent(urlVedtak, validToken, HttpMethod.Get)
-                        testInvalidPersonIdent(urlVedtak, validToken, HttpMethod.Post)
+                }
+
+                it("Creates vedtak and publish to infotrygd success with kvittering not OK") {
+                    mockInfotrygdKvitteringReceived(kvitteringOk = false)
+
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Created
+
+                        verify(exactly = 1) { infotrygdMQSender.sendToMQ(any(), any()) }
+
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+                        vedtakResponse.infotrygdStatus shouldBeEqualTo InfotrygdStatus.KVITTERING_FEIL.name
                     }
+                }
+
+                it("Throws error when document is empty") {
+                    val vedtakWithoutDocument = vedtakRequestDTO.copy(document = emptyList())
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakWithoutDocument))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+                it("Throws error when begrunnelse is empty") {
+                    val vedtakWithoutBegrunnelse = vedtakRequestDTO.copy(begrunnelse = "")
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakWithoutBegrunnelse))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+                it("Returns status Conflict when vedtak not ferdigbehandlet exists") {
+                    createVedtak(vedtakRequestDTO)
+
+                    with(
+                        handleRequest(HttpMethod.Post, urlVedtak) {
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                            setBody(objectMapper.writeValueAsString(vedtakRequestDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Conflict
+                    }
+                }
+            }
+
+            describe("PUT vedtak ferdigbehandlet") {
+                it("Sets vedtak ferdigbehandlet and updates veileder") {
+                    val vedtak = createVedtak(vedtakRequestDTO)
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/ferdigbehandling") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validTokenOther))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+                        val vedtakResponse = objectMapper.readValue(response.content, VedtakResponseDTO::class.java)
+                        vedtakResponse.uuid shouldBeEqualTo vedtak.uuid
+                        vedtakResponse.ferdigbehandletAt shouldNotBe null
+                        vedtakResponse.ferdigbehandletBy shouldBeEqualTo UserConstants.VEILEDER_IDENT_OTHER
+
+                        val vedtakPersisted = vedtakRepository.getVedtak(vedtak.uuid)
+
+                        vedtakPersisted.isFerdigbehandlet() shouldBe true
+                        vedtakPersisted.getFerdigbehandletStatus()!!.veilederident shouldBeEqualTo UserConstants.VEILEDER_IDENT_OTHER
+                    }
+                }
+                it("Throws error when ferdigstiller unknown vedtak") {
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${UUID.randomUUID()}/ferdigbehandling") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+                it("Throws error when ferdigbehandler already ferdigbehandlet vedtak") {
+                    val vedtak = createVedtak(vedtakRequestDTO)
+                    vedtakService.ferdigbehandleVedtak(vedtak, UserConstants.VEILEDER_IDENT)
+                    with(
+                        handleRequest(HttpMethod.Put, "$urlVedtak/${vedtak.uuid}/ferdigbehandling") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(NAV_PERSONIDENT_HEADER, personident.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+            }
+
+            describe("Unhappy paths") {
+                it("Returns status Unauthorized if no token is supplied") {
+                    testMissingToken(urlVedtak, HttpMethod.Get)
+                    testMissingToken(urlVedtak, HttpMethod.Post)
+                }
+                it("Returns status Forbidden if denied access to person") {
+                    testDeniedPersonAccess(urlVedtak, validToken, HttpMethod.Get)
+                    testDeniedPersonAccess(urlVedtak, validToken, HttpMethod.Post)
+                }
+                it("Returns status BadRequest if no $NAV_PERSONIDENT_HEADER is supplied") {
+                    testMissingPersonIdent(urlVedtak, validToken, HttpMethod.Get)
+                    testMissingPersonIdent(urlVedtak, validToken, HttpMethod.Post)
+                }
+                it("Returns status BadRequest if $NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied") {
+                    testInvalidPersonIdent(urlVedtak, validToken, HttpMethod.Get)
+                    testInvalidPersonIdent(urlVedtak, validToken, HttpMethod.Post)
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/PublishMQCronjobSpek.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.generator.generateDocumentComponent
 import no.nav.syfo.infrastructure.database.dropData
 import no.nav.syfo.infrastructure.database.getPublishedInfotrygdAt
 import no.nav.syfo.infrastructure.database.repository.VedtakRepository
+import no.nav.syfo.infrastructure.database.setVedtakCreatedAt
 import no.nav.syfo.infrastructure.infotrygd.InfotrygdService
 import no.nav.syfo.infrastructure.journalforing.JournalforingService
 import no.nav.syfo.infrastructure.mq.InfotrygdMQSender
@@ -22,6 +23,7 @@ import org.amshove.kluent.shouldNotBe
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDate
+import java.time.OffsetDateTime
 
 class PublishMQCronjobSpek : Spek({
 
@@ -48,9 +50,26 @@ class PublishMQCronjobSpek : Spek({
             }
 
             describe("Cronjob sender lagrede vedtak") {
-                it("Sender lagret vedtak") {
-                    val fom = LocalDate.now()
-                    val tom = LocalDate.now().plusDays(30)
+                val fom = LocalDate.now()
+                val tom = LocalDate.now().plusDays(30)
+
+                it("Sender ikke vedtak lagret nå") {
+                    runBlocking {
+                        vedtakService.createVedtak(
+                            personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+                            veilederident = UserConstants.VEILEDER_IDENT,
+                            begrunnelse = "begrunnelse",
+                            document = generateDocumentComponent("begrunnelse"),
+                            fom = fom,
+                            tom = tom,
+                            callId = "callId",
+                        )
+                        publishMQCronjob.run()
+                    }
+
+                    verify(exactly = 0) { mqSenderMock.sendToMQ(any(), any()) }
+                }
+                it("Sender vedtak lagret for 1 minutt siden") {
                     val vedtak = runBlocking {
                         vedtakService.createVedtak(
                             personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
@@ -62,6 +81,7 @@ class PublishMQCronjobSpek : Spek({
                             callId = "callId",
                         )
                     }
+                    database.setVedtakCreatedAt(OffsetDateTime.now().minusMinutes(1), vedtak.uuid)
 
                     vedtak.infotrygdStatus shouldBeEqualTo InfotrygdStatus.IKKE_SENDT
                     database.getPublishedInfotrygdAt(vedtak.uuid) shouldBe null

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
@@ -118,6 +118,23 @@ fun TestDatabase.getVedtakStatusPublishedAt(
         }
     }
 
+fun TestDatabase.setVedtakCreatedAt(createdAt: OffsetDateTime, uuid: UUID) {
+    this.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            UPDATE vedtak
+            SET created_at = ?
+            WHERE uuid = ?
+            """
+        ).use {
+            it.setObject(1, createdAt)
+            it.setString(2, uuid.toString())
+            it.execute()
+        }
+        connection.commit()
+    }
+}
+
 private const val queryGetVedtak =
     """
         SELECT * FROM vedtak WHERE uuid = ?


### PR DESCRIPTION
Forsøker publisering til infotrygd i api-kallet som oppretter vedaket. Venter så 1sek på å motta kvittering (konsumering av kvittering skjer i egen bakgrunnsjobb) og henter deretter vedtak fra databasen som inneholder oppdatert status på kvittering fra infotrygd. Ved feil/manglende kvittering kan vi vise informasjon om dette til veileder i vedtak-fattet-siden.