### PR TITLE
IS-3065: Allow vedtak til-dato back in time

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/VedtakEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/VedtakEndpoints.kt
@@ -15,7 +15,6 @@ import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontro
 import no.nav.syfo.util.getCallId
 import no.nav.syfo.util.getNAVIdent
 import no.nav.syfo.util.getPersonident
-import java.time.LocalDate
 import java.util.UUID
 
 const val vedtakUUIDParam = "vedtakUUID"
@@ -52,8 +51,8 @@ fun Route.registerVedtakEndpoints(
             if (requestDTO.begrunnelse.isBlank() || requestDTO.document.isEmpty()) {
                 throw IllegalArgumentException("Vedtak can't have an empty begrunnelse or document")
             }
-            if (requestDTO.tom.isBefore(LocalDate.now()) || requestDTO.tom.isBefore(requestDTO.fom)) {
-                throw IllegalArgumentException("Tildato i vedtak kan ikke være tilbake i tid eller før fradato.")
+            if (requestDTO.tom.isBefore(requestDTO.fom)) {
+                throw IllegalArgumentException("Tildato i vedtak kan ikke være før fradato.")
             }
 
             val personident = call.getPersonident()

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/VedtakEndpointsSpek.kt
@@ -244,7 +244,7 @@ object VedtakEndpointsSpek : Spek({
                 }
             }
 
-            it("Error when tom-date is back in time") {
+            it("Creates vedtak back in time") {
                 testApplication {
                     val client = setupApiAndClient()
                     val vedtakRequestDTOInvalidTom = VedtakRequestDTO(
@@ -261,7 +261,7 @@ object VedtakEndpointsSpek : Spek({
                         setBody(vedtakRequestDTOInvalidTom)
                     }
 
-                    response.status shouldBeEqualTo HttpStatusCode.BadRequest
+                    response.status shouldBeEqualTo HttpStatusCode.Created
                 }
             }
 


### PR DESCRIPTION
Det er avklart at vi trenger å åpne opp igjen så man kan fatte vedtak med fom- og tom-dato tilbake i tid.