### PR TITLE
IS-3350: Setter frist på gosys-oppgavene

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/gosysoppgave/OppgaveRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/gosysoppgave/OppgaveRequest.kt
@@ -12,4 +12,5 @@ data class OppgaveRequest(
     val beskrivelse: String,
     val prioritet: String,
     val aktivDato: LocalDate = LocalDate.now(),
+    val fristFerdigstillelse: LocalDate = LocalDate.now(),
 )

--- a/src/test/kotlin/no/nav/syfo/infrastructure/gosysoppgave/GosysOppgaveServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/gosysoppgave/GosysOppgaveServiceSpek.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.infrastructure.clients.gosysoppgave.OppgaveResponse
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
 
 class GosysOppgaveServiceSpek : Spek({
     describe(GosysOppgaveService::class.java.simpleName) {
@@ -45,7 +46,8 @@ class GosysOppgaveServiceSpek : Spek({
                     gosysOppgaveClientMock.createOppgave(
                         request = match {
                             it.personident == vedtak.personident.value &&
-                                it.journalpostId == vedtak.journalpostId!!.value
+                                it.journalpostId == vedtak.journalpostId!!.value &&
+                                it.fristFerdigstillelse == LocalDate.now()
                         },
                         correlationId = vedtak.uuid,
                     )


### PR DESCRIPTION
Etter ønske fra NAY: _Per dags dato klarer vi ikke å fange opp de automatisk genererte oppgavene i systemet uten et veldig spesifikt søk i gamle Gosys. Vi ønsker helst at frist er samme dato som registrert dato, dette fordi at vi ønsker at disse skal ligge fremst i bunken._ 